### PR TITLE
Terminate stuck workers and improve concurrency handling

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json && tsc --project tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "type-check": "tsc --noEmit",
     "prepare": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
We have observed our pyodide worker getting stuck hard.  While this is something I want to fix on the usage side, it's generally not nice if there is no recovery.  This now hard terminates a process if the claim lease does not get picked up for twice the duration by default.

This is a saner behavior in general because it allows a system to self heal in more cases.

This also lets workers pick up more work before a batch is done.