### PR TITLE
fix sdk dependencies

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -13,7 +13,7 @@ Durable execution (or durable workflows) is a way to run long-lived, reliable fu
 ## Installation
 
 ```bash
-npm install absurd-sdk
+npm install absurd-sdk pg
 ```
 
 ## Prerequisites
@@ -31,9 +31,9 @@ absurdctl create-queue -d your-database-name default
 ```typescript
 import { Absurd } from "absurd-sdk";
 
-const app = new Absurd({
-  connectionString: "postgresql://localhost/mydb",
-});
+const app = new Absurd(
+  "postgresql://localhost/mydb",
+);
 
 // Register a task
 app.registerTask({ name: "order-fulfillment" }, async (params, ctx) => {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -8,16 +8,16 @@
       "name": "absurd-sdk",
       "version": "0.0.4",
       "license": "Apache-2.0",
-      "dependencies": {
-        "pg": "^8.13.1",
-        "typescript": "^5.9.3"
-      },
       "devDependencies": {
         "@types/node": "^22.10.2",
-        "@types/pg": "^8.11.10"
+        "@types/pg": "^8.11.10",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "pg": "^8.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -70,18 +70,12 @@
         }
       }
     },
-    "node_modules/pg-cloudflare": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/pg-connection-string": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
       "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -97,6 +91,7 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
       "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -128,6 +123,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -176,6 +172,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -184,6 +181,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -36,13 +36,13 @@
   },
   "author": "",
   "license": "Apache-2.0",
-  "dependencies": {
-    "pg": "^8.13.1",
-    "typescript": "^5.9.3"
+  "peerDependencies": {
+    "pg": "^8.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
-    "@types/pg": "^8.11.10"
+    "@types/pg": "^8.11.10",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Typescript is a development dependency, not a runtime dependency.

pg as a peer feels like a better fit for the sdk, usually apps will have pg already installed since they are using it for the rest of their app. It also has the added "flair" that the library shows up as 0 dependencies on npm.

Also fixed a bad example in the README, although I would recommend preferably switching the constructor of Absurd to take a parameter object like the "typo" is a better fit since we don't have keyword param syntax like python in js/ts