### PR TITLE
Change Absurd constructor and fix small temporary resource leak

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -31,7 +31,7 @@ absurdctl create-queue -d your-database-name default
 ```typescript
 import { Absurd } from "absurd-sdk";
 
-const app = new Absurd("postgresql://localhost/mydb");
+const app = new Absurd({ db: "postgresql://localhost/mydb" });
 
 // Register a task
 app.registerTask({ name: "order-fulfillment" }, async (params, ctx) => {


### PR DESCRIPTION
This changes the constructor of `Absurd` to take an object with keys instead of positional arguments.  Additionally it changes how the system sleeps between polls which avoids having some sleep promises pending around for nothing.

This is a backwards incompatible change.