### PR TITLE
Fix absurdctl spawn-task

### DIFF
--- a/absurdctl
+++ b/absurdctl
@@ -793,10 +793,7 @@ def cmd_spawn_task(args):
             '{queue}',
             '{task_name}',
             '{params_json}'::jsonb,
-            {headers_json},
-            {options.max_attempts or "NULL"},
-            {retry_json},
-            {cancellation_json}
+            {headers_json}
         );
     """
 


### PR DESCRIPTION
I was getting errors spawning tasks without these changes doing

```
./absurdctl spawn-task --queue reports hello-world -P name=Lily
```