### PR TITLE
Add hooks to the SDK

### DIFF
--- a/habitat/ui/src/views/Tasks.tsx
+++ b/habitat/ui/src/views/Tasks.tsx
@@ -17,7 +17,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { type TaskDetail, type TaskSummary, fetchTasks, fetchTask } from "@/lib/api";
+import {
+  type TaskDetail,
+  type TaskSummary,
+  fetchTasks,
+  fetchTask,
+} from "@/lib/api";
 import { TaskStatusBadge } from "@/components/TaskStatusBadge";
 import { IdDisplay } from "@/components/IdDisplay";
 import { AutoRefreshToggle } from "@/components/AutoRefreshToggle";
@@ -236,7 +241,9 @@ export default function Tasks() {
   >({});
 
   // Use a store with reconcile for fine-grained updates - only changed items re-render
-  const [tasks, setTasks] = createStore<{ items: TaskSummary[] }>({ items: [] });
+  const [tasks, setTasks] = createStore<{ items: TaskSummary[] }>({
+    items: [],
+  });
 
   // Reconcile tasks when taskList changes - this diffs by runId
   createEffect(() => {

--- a/sdks/python/tests/test_hooks.py
+++ b/sdks/python/tests/test_hooks.py
@@ -1,0 +1,467 @@
+"""Tests for hooks and contextvars support."""
+
+import asyncio
+import contextvars
+from typing import Any
+
+import pytest
+from psycopg import sql
+
+from absurd_sdk import (
+    Absurd,
+    AsyncAbsurd,
+    TaskContext,
+    AsyncTaskContext,
+    SpawnOptions,
+    get_current_context,
+)
+
+
+def _fetch_run(conn, queue, run_id):
+    query = sql.SQL(
+        "select state, result from absurd.{table} where run_id = %s"
+    ).format(table=sql.Identifier(f"r_{queue}"))
+    return conn.execute(query, (run_id,)).fetchone()
+
+
+class TestBeforeSpawnHook:
+    """Tests for the before_spawn hook."""
+
+    def test_sync_before_spawn_can_inject_headers(self, conn, queue_name):
+        """before_spawn hook can inject headers into spawn options."""
+        queue = queue_name("hooks")
+        
+        captured_headers = []
+        
+        def before_spawn(task_name: str, params: Any, options: SpawnOptions) -> SpawnOptions:
+            return {
+                **options,
+                "headers": {
+                    **(options.get("headers") or {}),
+                    "trace_id": "trace-123",
+                    "correlation_id": "corr-456",
+                },
+            }
+        
+        client = Absurd(conn, queue_name=queue, hooks={"before_spawn": before_spawn})
+        client.create_queue()
+        
+        @client.register_task("capture-headers")
+        def capture_headers(params, ctx: TaskContext):
+            captured_headers.append(dict(ctx.headers))
+            return "done"
+        
+        client.spawn("capture-headers", {"test": True})
+        client.work_batch(worker_id="worker1")
+        
+        assert captured_headers == [{"trace_id": "trace-123", "correlation_id": "corr-456"}]
+
+    def test_sync_before_spawn_preserves_existing_headers(self, conn, queue_name):
+        """before_spawn hook preserves existing headers when adding new ones."""
+        queue = queue_name("hooks")
+        
+        captured_headers = []
+        
+        def before_spawn(task_name: str, params: Any, options: SpawnOptions) -> SpawnOptions:
+            return {
+                **options,
+                "headers": {
+                    **(options.get("headers") or {}),
+                    "injected": "by-hook",
+                },
+            }
+        
+        client = Absurd(conn, queue_name=queue, hooks={"before_spawn": before_spawn})
+        client.create_queue()
+        
+        @client.register_task("merge-headers")
+        def merge_headers(params, ctx: TaskContext):
+            captured_headers.append(dict(ctx.headers))
+            return "done"
+        
+        client.spawn("merge-headers", {}, headers={"existing": "user-provided"})
+        client.work_batch(worker_id="worker1")
+        
+        assert captured_headers == [{"existing": "user-provided", "injected": "by-hook"}]
+
+
+class TestAsyncBeforeSpawnHook:
+    """Tests for the async before_spawn hook."""
+
+    def test_async_before_spawn_can_inject_headers(self, db_dsn, conn, queue_name):
+        """Async before_spawn hook can inject headers."""
+        queue = queue_name("hooks")
+        
+        # Create queue with sync client
+        Absurd(conn, queue_name=queue).create_queue()
+        
+        captured_headers = []
+        
+        async def before_spawn(task_name: str, params: Any, options: SpawnOptions) -> SpawnOptions:
+            await asyncio.sleep(0.01)  # Simulate async operation
+            return {
+                **options,
+                "headers": {
+                    **(options.get("headers") or {}),
+                    "async_header": "fetched-value",
+                },
+            }
+        
+        async def run():
+            client = AsyncAbsurd(db_dsn, queue_name=queue, hooks={"before_spawn": before_spawn})
+            
+            @client.register_task("async-header")
+            async def async_header(params, ctx: AsyncTaskContext):
+                captured_headers.append(dict(ctx.headers))
+                return "done"
+            
+            await client.spawn("async-header", {})
+            await client.work_batch(worker_id="worker1")
+            await client.close()
+        
+        asyncio.run(run())
+        
+        assert captured_headers == [{"async_header": "fetched-value"}]
+
+
+class TestWrapTaskExecutionHook:
+    """Tests for the wrap_task_execution hook."""
+
+    def test_sync_wrap_task_execution(self, conn, queue_name):
+        """wrap_task_execution hook wraps task execution."""
+        queue = queue_name("hooks")
+        
+        execution_order = []
+        
+        def wrap_execution(ctx, execute):
+            execution_order.append("before")
+            result = execute()
+            execution_order.append("after")
+            return result
+        
+        client = Absurd(conn, queue_name=queue, hooks={"wrap_task_execution": wrap_execution})
+        client.create_queue()
+        
+        @client.register_task("wrapped-task")
+        def wrapped_task(params, ctx):
+            execution_order.append("handler")
+            return "done"
+        
+        client.spawn("wrapped-task", {})
+        client.work_batch(worker_id="worker1")
+        
+        assert execution_order == ["before", "handler", "after"]
+
+    def test_async_wrap_task_execution(self, db_dsn, conn, queue_name):
+        """Async wrap_task_execution hook wraps task execution."""
+        queue = queue_name("hooks")
+        
+        Absurd(conn, queue_name=queue).create_queue()
+        
+        execution_order = []
+        
+        async def wrap_execution(ctx, execute):
+            execution_order.append("before")
+            result = await execute()
+            execution_order.append("after")
+            return result
+        
+        async def run():
+            client = AsyncAbsurd(db_dsn, queue_name=queue, hooks={"wrap_task_execution": wrap_execution})
+            
+            @client.register_task("wrapped-task")
+            async def wrapped_task(params, ctx):
+                execution_order.append("handler")
+                return "done"
+            
+            await client.spawn("wrapped-task", {})
+            await client.work_batch(worker_id="worker1")
+            await client.close()
+        
+        asyncio.run(run())
+        
+        assert execution_order == ["before", "handler", "after"]
+
+
+class TestContextvarsIntegration:
+    """Tests for contextvars integration."""
+
+    def test_sync_contextvar_propagation(self, conn, queue_name):
+        """Contextvars can be propagated via hooks."""
+        queue = queue_name("hooks")
+        
+        trace_context: contextvars.ContextVar[dict] = contextvars.ContextVar("trace_context")
+        
+        captured_in_handler = []
+        
+        def before_spawn(task_name: str, params: Any, options: SpawnOptions) -> SpawnOptions:
+            ctx = trace_context.get(None)
+            if ctx:
+                return {
+                    **options,
+                    "headers": {
+                        **(options.get("headers") or {}),
+                        "trace_id": ctx["trace_id"],
+                        "span_id": ctx["span_id"],
+                    },
+                }
+            return options
+        
+        def wrap_execution(ctx, execute):
+            headers = ctx.headers
+            trace_id = headers.get("trace_id")
+            span_id = headers.get("span_id")
+            if trace_id and span_id:
+                token = trace_context.set({"trace_id": trace_id, "span_id": span_id})
+                try:
+                    return execute()
+                finally:
+                    trace_context.reset(token)
+            return execute()
+        
+        client = Absurd(
+            conn,
+            queue_name=queue,
+            hooks={"before_spawn": before_spawn, "wrap_task_execution": wrap_execution},
+        )
+        client.create_queue()
+        
+        @client.register_task("contextvar-test")
+        def contextvar_test(params, ctx):
+            captured_in_handler.append(trace_context.get(None))
+            return "done"
+        
+        # Spawn within a trace context
+        trace_context.set({"trace_id": "trace-abc", "span_id": "span-xyz"})
+        client.spawn("contextvar-test", {})
+        
+        # Clear the context before execution (simulating different process)
+        trace_context.set(None)
+        
+        # Execute - should restore context from headers
+        client.work_batch(worker_id="worker1")
+        
+        assert captured_in_handler == [{"trace_id": "trace-abc", "span_id": "span-xyz"}]
+
+    def test_async_contextvar_propagation(self, db_dsn, conn, queue_name):
+        """Async contextvars can be propagated via hooks."""
+        queue = queue_name("hooks")
+        
+        Absurd(conn, queue_name=queue).create_queue()
+        
+        trace_context: contextvars.ContextVar[dict] = contextvars.ContextVar("trace_context")
+        
+        captured_in_handler = []
+        
+        def before_spawn(task_name: str, params: Any, options: SpawnOptions) -> SpawnOptions:
+            ctx = trace_context.get(None)
+            if ctx:
+                return {
+                    **options,
+                    "headers": {
+                        **(options.get("headers") or {}),
+                        "trace_id": ctx["trace_id"],
+                    },
+                }
+            return options
+        
+        async def wrap_execution(ctx, execute):
+            headers = ctx.headers
+            trace_id = headers.get("trace_id")
+            if trace_id:
+                token = trace_context.set({"trace_id": trace_id})
+                try:
+                    return await execute()
+                finally:
+                    trace_context.reset(token)
+            return await execute()
+        
+        async def run():
+            client = AsyncAbsurd(
+                db_dsn,
+                queue_name=queue,
+                hooks={"before_spawn": before_spawn, "wrap_task_execution": wrap_execution},
+            )
+            
+            @client.register_task("async-contextvar-test")
+            async def contextvar_test(params, ctx):
+                captured_in_handler.append(trace_context.get(None))
+                return "done"
+            
+            # Spawn within a trace context
+            trace_context.set({"trace_id": "async-trace-123"})
+            await client.spawn("async-contextvar-test", {})
+            
+            # Clear the context
+            trace_context.set(None)
+            
+            # Execute - should restore context
+            await client.work_batch(worker_id="worker1")
+            await client.close()
+        
+        asyncio.run(run())
+        
+        assert captured_in_handler == [{"trace_id": "async-trace-123"}]
+
+
+class TestGetCurrentContext:
+    """Tests for get_current_context() function."""
+
+    def test_sync_get_current_context(self, conn, queue_name):
+        """get_current_context() returns TaskContext during execution."""
+        queue = queue_name("hooks")
+        
+        client = Absurd(conn, queue_name=queue)
+        client.create_queue()
+        
+        captured_contexts = []
+        
+        @client.register_task("context-test")
+        def context_test(params, ctx):
+            current = get_current_context()
+            captured_contexts.append(current)
+            return "done"
+        
+        client.spawn("context-test", {})
+        client.work_batch(worker_id="worker1")
+        
+        assert len(captured_contexts) == 1
+        assert isinstance(captured_contexts[0], TaskContext)
+
+    def test_sync_get_current_context_outside_task(self):
+        """get_current_context() returns None outside task execution."""
+        assert get_current_context() is None
+
+    def test_async_get_current_context(self, db_dsn, conn, queue_name):
+        """Async get_current_context() returns AsyncTaskContext during execution."""
+        queue = queue_name("hooks")
+        
+        Absurd(conn, queue_name=queue).create_queue()
+        
+        captured_contexts = []
+        
+        async def run():
+            client = AsyncAbsurd(db_dsn, queue_name=queue)
+            
+            @client.register_task("async-context-test")
+            async def context_test(params, ctx):
+                current = get_current_context()
+                captured_contexts.append(current)
+                return "done"
+            
+            await client.spawn("async-context-test", {})
+            await client.work_batch(worker_id="worker1")
+            await client.close()
+        
+        asyncio.run(run())
+        
+        assert len(captured_contexts) == 1
+        assert isinstance(captured_contexts[0], AsyncTaskContext)
+
+    def test_async_concurrent_tasks_have_isolated_contexts(self, db_dsn, conn, queue_name):
+        """Concurrent async tasks each have their own isolated context."""
+        queue = queue_name("hooks")
+        
+        Absurd(conn, queue_name=queue).create_queue()
+        
+        captured_task_ids = []
+        
+        async def run():
+            client = AsyncAbsurd(db_dsn, queue_name=queue)
+            
+            @client.register_task("concurrent-test")
+            async def concurrent_test(params, ctx):
+                # Simulate some async work
+                await asyncio.sleep(0.05)
+                current = get_current_context()
+                captured_task_ids.append((params["task_num"], current.task_id if current else None))
+                return f"done-{params['task_num']}"
+            
+            # Spawn multiple tasks
+            spawned = []
+            for i in range(3):
+                result = await client.spawn("concurrent-test", {"task_num": i})
+                spawned.append(result)
+            
+            # Process all tasks
+            for _ in range(3):
+                await client.work_batch(worker_id="worker1")
+            
+            await client.close()
+            return spawned
+        
+        spawned = asyncio.run(run())
+        
+        # Each captured context should match the correct task
+        assert len(captured_task_ids) == 3
+        for task_num, captured_id in captured_task_ids:
+            expected_id = spawned[task_num]["task_id"]
+            assert captured_id == expected_id, f"Task {task_num} got wrong context"
+
+
+class TestChildSpawnInheritsContext:
+    """Tests that child tasks spawned from within a task inherit context."""
+
+    def test_sync_child_spawn_inherits_context(self, conn, queue_name):
+        """Child task spawned from parent inherits trace context via hooks."""
+        queue = queue_name("hooks")
+        
+        trace_context: contextvars.ContextVar[dict] = contextvars.ContextVar("trace_context")
+        
+        child_trace_id = []
+        
+        def before_spawn(task_name: str, params: Any, options: SpawnOptions) -> SpawnOptions:
+            ctx = trace_context.get(None)
+            if ctx:
+                return {
+                    **options,
+                    "headers": {
+                        **(options.get("headers") or {}),
+                        "trace_id": ctx["trace_id"],
+                    },
+                }
+            return options
+        
+        def wrap_execution(ctx, execute):
+            headers = ctx.headers
+            trace_id = headers.get("trace_id")
+            if trace_id:
+                token = trace_context.set({"trace_id": trace_id})
+                try:
+                    return execute()
+                finally:
+                    trace_context.reset(token)
+            return execute()
+        
+        client = Absurd(
+            conn,
+            queue_name=queue,
+            hooks={"before_spawn": before_spawn, "wrap_task_execution": wrap_execution},
+        )
+        client.create_queue()
+        
+        @client.register_task("parent-task")
+        def parent_task(params, ctx):
+            # Spawn child - should inherit trace context via beforeSpawn hook
+            client.spawn("child-task", {})
+            return "parent-done"
+        
+        @client.register_task("child-task")
+        def child_task(params, ctx):
+            headers = ctx.headers
+            child_trace_id.append(headers.get("trace_id"))
+            return "child-done"
+        
+        # Spawn parent with trace context
+        trace_context.set({"trace_id": "parent-trace"})
+        client.spawn("parent-task", {})
+        
+        # Clear context
+        trace_context.set(None)
+        
+        # Execute parent (which spawns child)
+        client.work_batch(worker_id="worker1")
+        # Execute child
+        client.work_batch(worker_id="worker1")
+        
+        assert child_trace_id == ["parent-trace"]

--- a/sdks/typescript/test/hooks.test.ts
+++ b/sdks/typescript/test/hooks.test.ts
@@ -1,0 +1,360 @@
+import { describe, test, expect, beforeAll, afterEach } from "vitest";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { pool, randomName } from "./setup.js";
+import { Absurd, type SpawnOptions, type TaskContext } from "../src/index.js";
+
+describe("Hooks", () => {
+  let queueName: string;
+
+  beforeAll(async () => {
+    queueName = randomName("hooks_queue");
+    const absurd = new Absurd({ db: pool, queueName });
+    await absurd.createQueue(queueName);
+  });
+
+  afterEach(async () => {
+    try {
+      await pool.query(
+        `TRUNCATE absurd.t_${queueName}, absurd.r_${queueName}, absurd.c_${queueName}, absurd.e_${queueName}, absurd.w_${queueName}`,
+      );
+    } catch (err: any) {
+      if (!err.message?.includes("does not exist")) {
+        throw err;
+      }
+    }
+  });
+
+  describe("beforeSpawn hook", () => {
+    test("can inject headers before spawn", async () => {
+      const injectedHeaders: SpawnOptions["headers"][] = [];
+
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          beforeSpawn: (_taskName, _params, options) => {
+            return {
+              ...options,
+              headers: {
+                ...options.headers,
+                traceId: "trace-123",
+                correlationId: "corr-456",
+              },
+            };
+          },
+        },
+      });
+
+      let capturedHeaders: any = null;
+      absurd.registerTask({ name: "capture-headers" }, async (_params, ctx) => {
+        capturedHeaders = ctx.headers;
+        return "done";
+      });
+
+      await absurd.spawn("capture-headers", { test: true });
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(capturedHeaders).toEqual({
+        traceId: "trace-123",
+        correlationId: "corr-456",
+      });
+    });
+
+    test("can use async beforeSpawn hook", async () => {
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          beforeSpawn: async (_taskName, _params, options) => {
+            // Simulate async operation (e.g., fetching context)
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return {
+              ...options,
+              headers: {
+                ...options.headers,
+                asyncHeader: "fetched-value",
+              },
+            };
+          },
+        },
+      });
+
+      let capturedHeader: any = null;
+      absurd.registerTask({ name: "async-header" }, async (_params, ctx) => {
+        capturedHeader = ctx.headers["asyncHeader"];
+        return "done";
+      });
+
+      await absurd.spawn("async-header", {});
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(capturedHeader).toBe("fetched-value");
+    });
+
+    test("preserves existing headers when adding new ones", async () => {
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          beforeSpawn: (_taskName, _params, options) => {
+            return {
+              ...options,
+              headers: {
+                ...options.headers,
+                injected: "by-hook",
+              },
+            };
+          },
+        },
+      });
+
+      let capturedHeaders: any = null;
+      absurd.registerTask({ name: "merge-headers" }, async (_params, ctx) => {
+        capturedHeaders = ctx.headers;
+        return "done";
+      });
+
+      await absurd.spawn(
+        "merge-headers",
+        {},
+        {
+          headers: { existing: "user-provided" },
+        },
+      );
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(capturedHeaders).toEqual({
+        existing: "user-provided",
+        injected: "by-hook",
+      });
+    });
+  });
+
+  describe("wrapTaskExecution hook", () => {
+    test("wraps task execution", async () => {
+      const executionOrder: string[] = [];
+
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          wrapTaskExecution: async (_ctx, execute) => {
+            executionOrder.push("before");
+            await execute();
+            executionOrder.push("after");
+          },
+        },
+      });
+
+      absurd.registerTask({ name: "wrapped-task" }, async () => {
+        executionOrder.push("handler");
+        return "done";
+      });
+
+      await absurd.spawn("wrapped-task", {});
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(executionOrder).toEqual(["before", "handler", "after"]);
+    });
+
+    test("provides TaskContext to wrapper", async () => {
+      let capturedTaskId: string | null = null;
+      let capturedHeaders: any = null;
+
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          beforeSpawn: (_taskName, _params, options) => ({
+            ...options,
+            headers: { traceId: "from-spawn" },
+          }),
+          wrapTaskExecution: async (ctx, execute) => {
+            capturedTaskId = ctx.taskID;
+            capturedHeaders = ctx.headers;
+            await execute();
+          },
+        },
+      });
+
+      absurd.registerTask({ name: "ctx-in-wrapper" }, async () => "done");
+
+      const { taskID } = await absurd.spawn("ctx-in-wrapper", {});
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(capturedTaskId).toBe(taskID);
+      expect(capturedHeaders).toEqual({ traceId: "from-spawn" });
+    });
+  });
+
+  describe("AsyncLocalStorage integration", () => {
+    test("full round-trip: inject context on spawn, restore on execution", async () => {
+      interface TraceContext {
+        traceId: string;
+        spanId: string;
+      }
+      const als = new AsyncLocalStorage<TraceContext>();
+
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          beforeSpawn: (_taskName, _params, options) => {
+            const store = als.getStore();
+            if (store) {
+              return {
+                ...options,
+                headers: {
+                  ...options.headers,
+                  traceId: store.traceId,
+                  spanId: store.spanId,
+                },
+              };
+            }
+            return options;
+          },
+          wrapTaskExecution: async (ctx, execute) => {
+            const traceId = ctx.headers["traceId"] as string | undefined;
+            const spanId = ctx.headers["spanId"] as string | undefined;
+            if (traceId && spanId) {
+              return als.run({ traceId, spanId }, execute);
+            }
+            return execute();
+          },
+        },
+      });
+
+      let capturedInHandler: TraceContext | undefined;
+      absurd.registerTask({ name: "als-test" }, async () => {
+        capturedInHandler = als.getStore();
+        return "done";
+      });
+
+      // Spawn within an ALS context
+      await als.run({ traceId: "trace-abc", spanId: "span-xyz" }, async () => {
+        await absurd.spawn("als-test", {});
+      });
+
+      // Execute the task (outside original ALS context)
+      await absurd.workBatch("worker1", 60, 1);
+
+      // Handler should have received the context via wrapTaskExecution
+      expect(capturedInHandler).toEqual({
+        traceId: "trace-abc",
+        spanId: "span-xyz",
+      });
+    });
+
+    test("child spawns inherit context from parent task", async () => {
+      interface TraceContext {
+        traceId: string;
+      }
+      const als = new AsyncLocalStorage<TraceContext>();
+
+      const absurd = new Absurd({
+        db: pool,
+        queueName,
+        hooks: {
+          beforeSpawn: (_taskName, _params, options) => {
+            const store = als.getStore();
+            if (store) {
+              return {
+                ...options,
+                headers: {
+                  ...options.headers,
+                  traceId: store.traceId,
+                },
+              };
+            }
+            return options;
+          },
+          wrapTaskExecution: async (ctx, execute) => {
+            const traceId = ctx.headers["traceId"] as string | undefined;
+            if (traceId) {
+              return als.run({ traceId }, execute);
+            }
+            return execute();
+          },
+        },
+      });
+
+      let childTraceId: string | undefined;
+
+      absurd.registerTask({ name: "parent-task" }, async (_params, _ctx) => {
+        // Spawn child task - should inherit trace context via beforeSpawn hook
+        await absurd.spawn("child-task", {});
+        return "parent-done";
+      });
+
+      absurd.registerTask({ name: "child-task" }, async (_params, ctx) => {
+        childTraceId = ctx.headers["traceId"] as string | undefined;
+        return "child-done";
+      });
+
+      // Spawn parent within ALS context
+      await als.run({ traceId: "parent-trace" }, async () => {
+        await absurd.spawn("parent-task", {});
+      });
+
+      // Execute parent task
+      await absurd.workBatch("worker1", 60, 1);
+      // Execute child task
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(childTraceId).toBe("parent-trace");
+    });
+  });
+
+  describe("TaskContext header accessors", () => {
+    test("headers returns undefined for missing key", async () => {
+      const absurd = new Absurd({ db: pool, queueName });
+
+      let result: any;
+      absurd.registerTask({ name: "no-headers" }, async (_params, ctx) => {
+        result = ctx.headers["nonexistent"];
+        return "done";
+      });
+
+      await absurd.spawn("no-headers", {});
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(result).toBeUndefined();
+    });
+
+    test("headers getter returns empty object when no headers set", async () => {
+      const absurd = new Absurd({ db: pool, queueName });
+
+      let result: any;
+      absurd.registerTask({ name: "empty-headers" }, async (_params, ctx) => {
+        result = ctx.headers;
+        return "done";
+      });
+
+      await absurd.spawn("empty-headers", {});
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(result).toEqual({});
+    });
+
+    test("headers getter returns all headers", async () => {
+      const absurd = new Absurd({ db: pool, queueName });
+
+      let result: any;
+      absurd.registerTask({ name: "all-headers" }, async (_params, ctx) => {
+        result = ctx.headers;
+        return "done";
+      });
+
+      await absurd.spawn(
+        "all-headers",
+        {},
+        {
+          headers: { a: 1, b: "two", c: true },
+        },
+      );
+      await absurd.workBatch("worker1", 60, 1);
+
+      expect(result).toEqual({ a: 1, b: "two", c: true });
+    });
+  });
+});


### PR DESCRIPTION
It's currently rather awkward to hook in tracing systems because it requires manually wrapping tasks.  This allows us to configure Sentry or other systems across task spawns and pickups.

Refs #22