### PR TITLE
Add emit-event command to absurdctl

### DIFF
--- a/absurdctl
+++ b/absurdctl
@@ -1561,7 +1561,7 @@ def cmd_emit_event(args):
 
     payload_json = build_json_params(options.params, options.base_payload)
 
-    queue = options.queue or "default"
+    queue = validate_queue_name(options.queue or "default")
 
     ensure_queue_exists(config, queue)
 
@@ -1573,9 +1573,16 @@ def cmd_emit_event(args):
     details.extend(get_common_db_details(config))
     print_verbose_configuration(options.verbose, details)
 
-    query = f"SELECT absurd.emit_event('{queue}', '{event_name}', '{payload_json}'::jsonb);"
-
-    run_psql(config, query)
+    query = "SELECT absurd.emit_event(:'queue', :'event_name', :'payload_json'::jsonb);"
+    run_psql(
+        config,
+        query,
+        variables={
+            "queue": queue,
+            "event_name": event_name,
+            "payload_json": payload_json,
+        },
+    )
     print(f"Event '{event_name}' emitted successfully to queue '{queue}'")
 
 

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -7,6 +7,7 @@ import pytest
 ABSURDCTL_PATH = Path(__file__).resolve().parents[1] / "absurdctl"
 MODULE = runpy.run_path(str(ABSURDCTL_PATH))
 validate_queue_name = MODULE["validate_queue_name"]
+cmd_emit_event = MODULE["cmd_emit_event"]
 
 
 @pytest.mark.parametrize(
@@ -36,3 +37,29 @@ def test_validate_queue_name_accepts_supported_names(queue_name):
 def test_validate_queue_name_rejects_unsafe_names(queue_name):
     with pytest.raises(SystemExit):
         validate_queue_name(queue_name)
+
+
+def test_emit_event_uses_parameterized_query(monkeypatch):
+    captured = {}
+
+    def fake_run_psql(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return ""
+
+    monkeypatch.setitem(cmd_emit_event.__globals__, "run_psql", fake_run_psql)
+    monkeypatch.setitem(cmd_emit_event.__globals__, "ensure_queue_exists", lambda *_: None)
+
+    cmd_emit_event(["-q", "default", "order.completed", "-P", "note=Bob's"])
+
+    assert captured["query"] == "SELECT absurd.emit_event(:'queue', :'event_name', :'payload_json'::jsonb);"
+    assert captured["variables"]["queue"] == "default"
+    assert captured["variables"]["event_name"] == "order.completed"
+    assert captured["variables"]["payload_json"] == '{"note": "Bob\'s"}'
+
+
+def test_emit_event_validates_queue_name(monkeypatch):
+    monkeypatch.setitem(cmd_emit_event.__globals__, "ensure_queue_exists", lambda *_: None)
+
+    with pytest.raises(SystemExit):
+        cmd_emit_event(["-q", "bad queue", "order.completed"])


### PR DESCRIPTION


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## AI Usage Disclosure

**Did you use AI assistance for this PR?**
- [ ] No AI was used
- [ ] AI was used minimally (e.g., for code formatting, minor suggestions)
- [x] AI was used extensively (e.g., for refactoring, significant code generation, algorithm design)

**If AI was used, please describe:**

Done using Claude Code Opus 4.5. I asked it to create `emit-event` similar to `spawn-task`. I tested that it works as expected.

## Contribution Agreement

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.

## Description

Allows emitting events from the command line to wake tasks waiting on awaitEvent. Follows the same parameter syntax as spawn-task with -P for payload fields and --payload for base JSON.
