### PR TITLE
Fix SQL injection vulnerabilities in absurdctl

### DIFF
--- a/absurdctl
+++ b/absurdctl
@@ -14,25 +14,26 @@ from urllib.parse import urlparse
 from optparse import OptionParser, IndentedHelpFormatter
 
 
-# Pattern for validating SQL identifiers (used in table names, can't be parameterized)
-IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
+# Queue names are interpolated into dynamic table names (t_<queue>, r_<queue>, ...)
+# so we must constrain characters to a safe subset.
+QUEUE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 
 
-def validate_identifier(value, name="identifier"):
-    """Validate that a value is a safe SQL identifier (letters, numbers, underscores, hyphens).
+def validate_queue_name(value):
+    """Validate queue names used in dynamic table names.
 
-    This is required for values used in table/column names which can't use psql variables.
-    For regular values in WHERE clauses, use run_psql(..., variables={}) instead.
+    Queue names may start with a letter or digit and may contain letters,
+    numbers, underscores, and hyphens.
     """
-    if not value or not IDENTIFIER_PATTERN.match(value):
+    if not value or not QUEUE_NAME_PATTERN.match(value):
         print(
-            f"Error: Invalid {name} '{value}'. Must start with a letter and contain only "
-            "letters, numbers, underscores, and hyphens.",
+            f"Error: Invalid queue name '{value}'. Must start with a letter or number "
+            "and contain only letters, numbers, underscores, and hyphens.",
             file=sys.stderr,
         )
         sys.exit(1)
     if len(value) > 63:
-        print(f"Error: {name} '{value}' is too long (max 63 characters).", file=sys.stderr)
+        print(f"Error: Queue name '{value}' is too long (max 63 characters).", file=sys.stderr)
         sys.exit(1)
     return value
 
@@ -417,7 +418,7 @@ def cmd_cleanup(args):
         parser.print_help()
         sys.exit(1)
 
-    queue_name = validate_identifier(args[0], "queue name")
+    queue_name = validate_queue_name(args[0])
     try:
         ttl_days = int(args[1])
     except ValueError:
@@ -545,7 +546,7 @@ def cmd_create_queue(args):
         parser.print_help()
         sys.exit(1)
 
-    queue_name = validate_identifier(args[0], "queue name")
+    queue_name = validate_queue_name(args[0])
     config = config_from_options(options)
 
     print_verbose_configuration(
@@ -583,7 +584,7 @@ def cmd_drop_queue(args):
         parser.print_help()
         sys.exit(1)
 
-    queue_name = validate_identifier(args[0], "queue name")
+    queue_name = validate_queue_name(args[0])
     config = config_from_options(options)
 
     ensure_queue_exists(config, queue_name)
@@ -813,7 +814,7 @@ def cmd_spawn_task(args):
             cancellation["maxDelay"] = options.max_delay
         cancellation_json = f"'{json.dumps(cancellation)}'::jsonb"
 
-    queue = validate_identifier(options.queue or "default", "queue name")
+    queue = validate_queue_name(options.queue or "default")
 
     ensure_queue_exists(config, queue)
 
@@ -1019,7 +1020,7 @@ def cmd_list_tasks(args):
 
     # Filter to specific queue if requested
     if options.queue:
-        validate_identifier(options.queue, "queue name")
+        validate_queue_name(options.queue)
         if options.queue not in queues:
             print(f"Queue '{options.queue}' does not exist", file=sys.stderr)
             sys.exit(1)
@@ -1129,7 +1130,7 @@ def cmd_cancel_task(args):
         sys.exit(1)
 
     task_id = args[0]
-    queue = validate_identifier(options.queue or "default", "queue name")
+    queue = validate_queue_name(options.queue or "default")
     config = config_from_options(options)
 
     try:

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import runpy
+
+import pytest
+
+
+ABSURDCTL_PATH = Path(__file__).resolve().parents[1] / "absurdctl"
+MODULE = runpy.run_path(str(ABSURDCTL_PATH))
+validate_queue_name = MODULE["validate_queue_name"]
+
+
+@pytest.mark.parametrize(
+    "queue_name",
+    [
+        "default",
+        "1jobs",
+        "queue_1",
+        "queue-1",
+        "9",
+    ],
+)
+def test_validate_queue_name_accepts_supported_names(queue_name):
+    assert validate_queue_name(queue_name) == queue_name
+
+
+@pytest.mark.parametrize(
+    "queue_name",
+    [
+        "",
+        "-bad",
+        "_bad",
+        "bad space",
+        "bad'quote",
+    ],
+)
+def test_validate_queue_name_rejects_unsafe_names(queue_name):
+    with pytest.raises(SystemExit):
+        validate_queue_name(queue_name)


### PR DESCRIPTION
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## AI Usage Disclosure

**Did you use AI assistance for this PR?**
- [ ] No AI was used
- [ ] AI was used minimally (e.g., for code formatting, minor suggestions)
- [x] AI was used extensively (e.g., for refactoring, significant code generation, algorithm design)

**If AI was used, please describe:**

While reading through the `absurd.sql` file to learn how it works, I wondered how inputs like `queue name` are were protected against SQL injection. 

It turns out that that is handled with the `%I` already.

I then checked how the `absurdctl` does it, and there seem to be issues there.

I think it's good to have some kind of sanitization here to prevent foot guns.

Sure, one would probably not try to do these things using absurdctl. Why would you.
But there can be mistakes made, with invalid characters.

## Contribution Agreement

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.


## Description

The CLI tool was vulnerable to SQL injection through user-provided input that was interpolated directly into SQL queries via f-strings.

Vulnerabilities fixed:

1. Value injection in WHERE clauses and function arguments:
   - queue_exists(): queue_name interpolated directly
   - cmd_create_queue/drop_queue(): queue_name in stored proc calls
   - cmd_cancel_task(): queue and task_id in stored proc call
   - cmd_list_tasks(): task_name filter in WHERE clause
   - cmd_dump_task(): task_id and run_id in WHERE clauses

   Fix: Use psql's -v flag with :'variable' syntax for safe parameter
   binding. Values are properly escaped by psql.

2. Identifier injection in dynamic table names:
   - Queries like f"SELECT ... FROM absurd.t_{queue}" allow injection since table names cannot be parameterized.

   Fix: Validate queue names against pattern ^[a-zA-Z][a-zA-Z0-9_-]*$
   before use in table name construction.

Example exploit (before fix):
  ./absurdctl cancel-task "x'); DROP TABLE absurd.queues; --"
  -> SELECT absurd.cancel_task('default', 'x'); DROP TABLE absurd.queues; --');

Provide a brief description of the changes in this PR here.