### PR TITLE
Habitat: add collapse/expand all toggle for task JSON payloads

### DIFF
--- a/habitat/ui/src/components/JSONViewer.tsx
+++ b/habitat/ui/src/components/JSONViewer.tsx
@@ -1,8 +1,9 @@
-import { createSignal, Show, For, createMemo } from "solid-js";
+import { createSignal, Show, For, createMemo, createEffect } from "solid-js";
 
 interface JSONViewerProps {
   data: any;
   label?: string;
+  collapseAll?: boolean;
 }
 
 type JSONToken =
@@ -27,6 +28,20 @@ export function JSONViewer(props: JSONViewerProps) {
     new Set(),
   );
   const [foldedPaths, setFoldedPaths] = createSignal<Set<string>>(new Set());
+
+  const allFoldablePaths = createMemo(() => collectFoldablePaths(props.data));
+
+  createEffect(() => {
+    if (props.collapseAll === undefined) {
+      return;
+    }
+
+    if (props.collapseAll) {
+      setFoldedPaths(new Set(allFoldablePaths()));
+    } else {
+      setFoldedPaths(new Set<string>());
+    }
+  });
 
   const errorInfo = () => extractErrorLike(props.data);
 
@@ -292,6 +307,37 @@ function tokenizeJSON(
   }
 
   return tokens;
+}
+
+function collectFoldablePaths(data: any, path: string = "$"): string[] {
+  if (data === null || typeof data !== "object") {
+    return [];
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return [];
+    }
+
+    return [
+      path,
+      ...data.flatMap((item, index) =>
+        collectFoldablePaths(item, `${path}[${index}]`),
+      ),
+    ];
+  }
+
+  const entries = Object.entries(data);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  return [
+    path,
+    ...entries.flatMap(([key, value]) =>
+      collectFoldablePaths(value, `${path}.${key}`),
+    ),
+  ];
 }
 
 type ErrorLikeInfo = {

--- a/habitat/ui/src/components/TaskDetailView.tsx
+++ b/habitat/ui/src/components/TaskDetailView.tsx
@@ -1,5 +1,5 @@
 import { A } from "@solidjs/router";
-import { For, Show } from "solid-js";
+import { For, Show, createSignal } from "solid-js";
 import { JSONViewer } from "@/components/JSONViewer";
 import { TaskStatusBadge } from "@/components/TaskStatusBadge";
 import { IdDisplay } from "@/components/IdDisplay";
@@ -45,19 +45,29 @@ function DetailContent(props: {
   const stateLabel = () =>
     props.detail.status?.toLowerCase() === "failed" ? "Failure" : "Final State";
   const isDefault = props.variant === "default";
+  const [collapseAllPayloads, setCollapseAllPayloads] = createSignal(false);
 
   return (
     <>
-      <Show when={props.taskLink}>
-        {(link) => (
-          <A
-            href={link()}
-            class={`${buttonVariants({ variant: "secondary", size: "sm" })} float-right items-center gap-1`}
-          >
-            View task history
-          </A>
-        )}
-      </Show>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class={buttonVariants({ variant: "secondary", size: "sm" })}
+          onClick={() => setCollapseAllPayloads((current) => !current)}
+        >
+          {collapseAllPayloads() ? "Expand all" : "Collapse all"}
+        </button>
+        <Show when={props.taskLink}>
+          {(link) => (
+            <A
+              href={link()}
+              class={`${buttonVariants({ variant: "secondary", size: "sm" })} items-center gap-1`}
+            >
+              View task history
+            </A>
+          )}
+        </Show>
+      </div>
 
       <Show when={isDefault}>
         <div class="grid gap-4 md:grid-cols-2">
@@ -128,6 +138,7 @@ function DetailContent(props: {
           <JSONViewer
             data={props.detail.retryStrategy}
             label="Retry Strategy"
+            collapseAll={collapseAllPayloads()}
           />
         </div>
       </Show>
@@ -181,7 +192,11 @@ function DetailContent(props: {
                   </dl>
                   <Show when={typeof wait.payload !== "undefined"}>
                     <div>
-                      <JSONViewer data={wait.payload} label="Wait payload" />
+                      <JSONViewer
+                        data={wait.payload}
+                        label="Wait payload"
+                        collapseAll={collapseAllPayloads()}
+                      />
                     </div>
                   </Show>
                   <Show when={typeof wait.eventPayload !== "undefined"}>
@@ -189,6 +204,7 @@ function DetailContent(props: {
                       <JSONViewer
                         data={wait.eventPayload}
                         label="Event payload"
+                        collapseAll={collapseAllPayloads()}
                       />
                     </div>
                   </Show>
@@ -201,19 +217,31 @@ function DetailContent(props: {
 
       <Show when={props.detail.params}>
         <div>
-          <JSONViewer data={props.detail.params} label="Parameters" />
+          <JSONViewer
+            data={props.detail.params}
+            label="Parameters"
+            collapseAll={collapseAllPayloads()}
+          />
         </div>
       </Show>
 
       <Show when={props.detail.headers}>
         <div>
-          <JSONViewer data={props.detail.headers} label="Headers" />
+          <JSONViewer
+            data={props.detail.headers}
+            label="Headers"
+            collapseAll={collapseAllPayloads()}
+          />
         </div>
       </Show>
 
       <Show when={props.detail.state !== undefined}>
         <div>
-          <JSONViewer data={props.detail.state} label={stateLabel()} />
+          <JSONViewer
+            data={props.detail.state}
+            label={stateLabel()}
+            collapseAll={collapseAllPayloads()}
+          />
         </div>
       </Show>
 
@@ -238,7 +266,10 @@ function DetailContent(props: {
                       )}
                     </Show>
                   </div>
-                  <JSONViewer data={checkpoint.state} />
+                  <JSONViewer
+                    data={checkpoint.state}
+                    collapseAll={collapseAllPayloads()}
+                  />
                 </div>
               )}
             </For>


### PR DESCRIPTION
As seen in screenshot.

By default shows all expanded, as usual, and adds a button "Collapse all"
<img width="2482" height="994" alt="CleanShot-2026-03-03-at-13 42 04@2x" src="https://github.com/user-attachments/assets/5f1456d4-5ddf-469b-944b-34c52e02ba44" />

When collapsed, shows "Expand all"
<img width="2482" height="898" alt="CleanShot-2026-03-03-at-13 41 59@2x" src="https://github.com/user-attachments/assets/52b61755-fbf8-4c1f-8c48-e7fb358950f5" />
