### PR TITLE
Experimental Partition Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,18 +33,18 @@ jobs:
         id: cache-pgcron-image
         uses: actions/cache@v4
         with:
-          path: /tmp/absurd-test-postgres16-pgcron-16-1.6.7.tar
+          path: /tmp/absurd-test-postgres16-pgcron-16-1.6.7-faketime6.tar
           key: ${{ runner.os }}-pgcron-image-${{ hashFiles('tests/docker/pg16-pgcron/Dockerfile') }}
 
       - name: Load cached pg_cron test image
         if: steps.cache-pgcron-image.outputs.cache-hit == 'true'
-        run: docker load --input /tmp/absurd-test-postgres16-pgcron-16-1.6.7.tar
+        run: docker load --input /tmp/absurd-test-postgres16-pgcron-16-1.6.7-faketime6.tar
 
       - name: Build and cache pg_cron test image
         if: steps.cache-pgcron-image.outputs.cache-hit != 'true'
         run: |
-          docker build -t absurd-test-postgres16-pgcron:16-1.6.7 tests/docker/pg16-pgcron
-          docker save absurd-test-postgres16-pgcron:16-1.6.7 --output /tmp/absurd-test-postgres16-pgcron-16-1.6.7.tar
+          docker build -t absurd-test-postgres16-pgcron:16-1.6.7-faketime6 tests/docker/pg16-pgcron
+          docker save absurd-test-postgres16-pgcron:16-1.6.7-faketime6 --output /tmp/absurd-test-postgres16-pgcron-16-1.6.7-faketime6.tar
 
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,22 @@ jobs:
         working-directory: sdks/typescript
         run: npm ci
 
+      - name: Restore pg_cron test image cache
+        id: cache-pgcron-image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/absurd-test-postgres16-pgcron-16-1.6.7.tar
+          key: ${{ runner.os }}-pgcron-image-${{ hashFiles('tests/docker/pg16-pgcron/Dockerfile') }}
+
+      - name: Load cached pg_cron test image
+        if: steps.cache-pgcron-image.outputs.cache-hit == 'true'
+        run: docker load --input /tmp/absurd-test-postgres16-pgcron-16-1.6.7.tar
+
+      - name: Build and cache pg_cron test image
+        if: steps.cache-pgcron-image.outputs.cache-hit != 'true'
+        run: |
+          docker build -t absurd-test-postgres16-pgcron:16-1.6.7 tests/docker/pg16-pgcron
+          docker save absurd-test-postgres16-pgcron:16-1.6.7 --output /tmp/absurd-test-postgres16-pgcron-16-1.6.7.tar
+
       - name: Run tests
         run: make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,12 +71,15 @@ Useful to keep in mind when working on the SQL:
 
 ### Database Tables (per queue)
 
-Each queue creates 5 tables:
+Each queue creates 5 core tables:
 - **t_{queue}** - Tasks (the logical unit of work)
 - **r_{queue}** - Runs (attempts to execute a task)
 - **c_{queue}** - Checkpoints (saved step results)
 - **e_{queue}** - Events (emitted signals)
 - **w_{queue}** - Wait registrations (tasks waiting for events)
+
+Partitioned queues additionally create:
+- **i_{queue}** - Idempotency key registry
 
 ### Notes on Schema
 

--- a/absurdctl
+++ b/absurdctl
@@ -1022,7 +1022,7 @@ def _fetch_queue_policy(config, queue_name):
           storage_mode,
           partition_lookahead::text,
           partition_lookback::text,
-          cleanup_ttl_seconds,
+          cleanup_ttl::text,
           cleanup_limit,
           detach_mode,
           detach_min_age::text
@@ -1042,7 +1042,7 @@ def _fetch_queue_policy(config, queue_name):
         "storage_mode": parts[1],
         "partition_lookahead": parts[2],
         "partition_lookback": parts[3],
-        "cleanup_ttl_seconds": parts[4],
+        "cleanup_ttl": parts[4],
         "cleanup_limit": parts[5],
         "detach_mode": parts[6],
         "detach_min_age": parts[7],
@@ -1054,7 +1054,7 @@ def _print_queue_policy(policy):
     print(f"  storage_mode: {policy['storage_mode']}")
     print(f"  partition_lookahead: {policy['partition_lookahead']}")
     print(f"  partition_lookback: {policy['partition_lookback']}")
-    print(f"  cleanup_ttl_seconds: {policy['cleanup_ttl_seconds']}")
+    print(f"  cleanup_ttl: {policy['cleanup_ttl']}")
     print(f"  cleanup_limit: {policy['cleanup_limit']}")
     print(f"  detach_mode: {policy['detach_mode']}")
     print(f"  detach_min_age: {policy['detach_min_age']}")
@@ -1077,11 +1077,10 @@ def cmd_queue_policy(args):
         help="Policy partition lookback interval (for example: '1 day')",
     )
     parser.add_option(
-        "--cleanup-ttl-seconds",
-        dest="cleanup_ttl_seconds",
-        type="int",
-        metavar="SECONDS",
-        help="Cleanup retention in seconds",
+        "--cleanup-ttl",
+        dest="cleanup_ttl",
+        metavar="INTERVAL",
+        help="Cleanup retention interval (for example: '30 days')",
     )
     parser.add_option(
         "--cleanup-limit",
@@ -1107,7 +1106,7 @@ def cmd_queue_policy(args):
 
     examples = [
         "absurdctl queue-policy myqueue",
-        "absurdctl queue-policy myqueue --cleanup-ttl-seconds 86400 --cleanup-limit 2000",
+        "absurdctl queue-policy myqueue --cleanup-ttl '30 days' --cleanup-limit 2000",
         "absurdctl queue-policy myqueue --partition-lookahead '42 days' --partition-lookback '2 days'",
         "absurdctl queue-policy myqueue --detach-mode empty --detach-min-age '30 days'",
     ]
@@ -1128,11 +1127,8 @@ def cmd_queue_policy(args):
         policy_payload["partition_lookahead"] = options.partition_lookahead
     if options.partition_lookback is not None:
         policy_payload["partition_lookback"] = options.partition_lookback
-    if options.cleanup_ttl_seconds is not None:
-        if options.cleanup_ttl_seconds < 0:
-            print("Error: --cleanup-ttl-seconds must be non-negative", file=sys.stderr)
-            sys.exit(1)
-        policy_payload["cleanup_ttl_seconds"] = options.cleanup_ttl_seconds
+    if options.cleanup_ttl is not None:
+        policy_payload["cleanup_ttl"] = options.cleanup_ttl
     if options.cleanup_limit is not None:
         if options.cleanup_limit < 1:
             print("Error: --cleanup-limit must be at least 1", file=sys.stderr)
@@ -2898,7 +2894,7 @@ Examples:
   absurdctl schema-version
   absurdctl cleanup myqueue 30
   absurdctl create-queue myqueue --storage-mode partitioned
-  absurdctl queue-policy myqueue --cleanup-ttl-seconds 604800
+  absurdctl queue-policy myqueue --cleanup-ttl '7 days'
   absurdctl cron --enable --queue myqueue
   absurdctl list-detach-candidates --queue myqueue
   absurdctl detach-candidate --queue myqueue 1a2b3c4d5e6f --drop

--- a/absurdctl
+++ b/absurdctl
@@ -895,9 +895,22 @@ def cmd_create_queue(args):
     """Create a new Absurd queue."""
     usage = "usage: %prog create-queue [options] QUEUE_NAME"
     parser = build_command_parser(usage)
+    parser.add_option(
+        "--storage-mode",
+        dest="storage_mode",
+        type="choice",
+        choices=["unpartitioned", "partitioned"],
+        default="unpartitioned",
+        help="Queue storage mode (default: unpartitioned)",
+    )
 
     options, args = parse_args_with_help(
-        parser, args, ["absurdctl create-queue myqueue"]
+        parser,
+        args,
+        [
+            "absurdctl create-queue myqueue",
+            "absurdctl create-queue jobs --storage-mode partitioned",
+        ],
     )
 
     if len(args) != 1:
@@ -910,12 +923,27 @@ def cmd_create_queue(args):
 
     print_verbose_configuration(
         options.verbose,
-        [("Queue", queue_name)] + get_common_db_details(config),
+        [("Queue", queue_name), ("Storage mode", options.storage_mode)]
+        + get_common_db_details(config),
     )
     if options.verbose:
         print(f"Creating queue '{queue_name}'...")
 
-    run_psql(config, "SELECT absurd.create_queue(:'queue_name');", variables={"queue_name": queue_name})
+    if options.storage_mode == "unpartitioned":
+        run_psql(
+            config,
+            "SELECT absurd.create_queue(:'queue_name');",
+            variables={"queue_name": queue_name},
+        )
+    else:
+        run_psql(
+            config,
+            "SELECT absurd.create_queue(:'queue_name', :'storage_mode');",
+            variables={
+                "queue_name": queue_name,
+                "storage_mode": options.storage_mode,
+            },
+        )
     print(f"Queue '{queue_name}' created successfully")
 
 
@@ -983,6 +1011,505 @@ def cmd_list_queues(args):
     ).strip()
     if result:
         print(result)
+
+
+def _fetch_queue_policy(config, queue_name):
+    rows = run_psql_csv(
+        config,
+        """
+        SELECT
+          queue_name,
+          storage_mode,
+          partition_lookahead::text,
+          partition_lookback::text,
+          cleanup_ttl_seconds,
+          cleanup_limit,
+          detach_mode,
+          detach_min_age::text
+        FROM absurd.get_queue_policy(:'queue_name')
+        """,
+        variables={"queue_name": queue_name},
+    )
+    if not rows:
+        return None
+
+    parts = rows[0]
+    if len(parts) < 8:
+        return None
+
+    return {
+        "queue_name": parts[0],
+        "storage_mode": parts[1],
+        "partition_lookahead": parts[2],
+        "partition_lookback": parts[3],
+        "cleanup_ttl_seconds": parts[4],
+        "cleanup_limit": parts[5],
+        "detach_mode": parts[6],
+        "detach_min_age": parts[7],
+    }
+
+
+def _print_queue_policy(policy):
+    print(f"Queue policy for '{policy['queue_name']}':")
+    print(f"  storage_mode: {policy['storage_mode']}")
+    print(f"  partition_lookahead: {policy['partition_lookahead']}")
+    print(f"  partition_lookback: {policy['partition_lookback']}")
+    print(f"  cleanup_ttl_seconds: {policy['cleanup_ttl_seconds']}")
+    print(f"  cleanup_limit: {policy['cleanup_limit']}")
+    print(f"  detach_mode: {policy['detach_mode']}")
+    print(f"  detach_min_age: {policy['detach_min_age']}")
+
+
+def cmd_queue_policy(args):
+    """Get or update queue maintenance policy."""
+    usage = "usage: %prog queue-policy [options] QUEUE_NAME"
+    parser = build_command_parser(usage)
+    parser.add_option(
+        "--partition-lookahead",
+        dest="partition_lookahead",
+        metavar="INTERVAL",
+        help="Policy partition lookahead interval (for example: '28 days')",
+    )
+    parser.add_option(
+        "--partition-lookback",
+        dest="partition_lookback",
+        metavar="INTERVAL",
+        help="Policy partition lookback interval (for example: '1 day')",
+    )
+    parser.add_option(
+        "--cleanup-ttl-seconds",
+        dest="cleanup_ttl_seconds",
+        type="int",
+        metavar="SECONDS",
+        help="Cleanup retention in seconds",
+    )
+    parser.add_option(
+        "--cleanup-limit",
+        dest="cleanup_limit",
+        type="int",
+        metavar="N",
+        help="Cleanup batch size",
+    )
+    parser.add_option(
+        "--detach-mode",
+        dest="detach_mode",
+        type="choice",
+        choices=["none", "empty"],
+        metavar="MODE",
+        help="Detach mode (none or empty)",
+    )
+    parser.add_option(
+        "--detach-min-age",
+        dest="detach_min_age",
+        metavar="INTERVAL",
+        help="Minimum partition age before detach consideration",
+    )
+
+    examples = [
+        "absurdctl queue-policy myqueue",
+        "absurdctl queue-policy myqueue --cleanup-ttl-seconds 86400 --cleanup-limit 2000",
+        "absurdctl queue-policy myqueue --partition-lookahead '42 days' --partition-lookback '2 days'",
+        "absurdctl queue-policy myqueue --detach-mode empty --detach-min-age '30 days'",
+    ]
+
+    options, args = parse_args_with_help(parser, args, examples)
+
+    if len(args) != 1:
+        print("Error: Missing required argument QUEUE_NAME", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    queue_name = validate_queue_name(args[0])
+    config = config_from_options(options)
+    ensure_queue_exists(config, queue_name)
+
+    policy_payload = {}
+    if options.partition_lookahead is not None:
+        policy_payload["partition_lookahead"] = options.partition_lookahead
+    if options.partition_lookback is not None:
+        policy_payload["partition_lookback"] = options.partition_lookback
+    if options.cleanup_ttl_seconds is not None:
+        if options.cleanup_ttl_seconds < 0:
+            print("Error: --cleanup-ttl-seconds must be non-negative", file=sys.stderr)
+            sys.exit(1)
+        policy_payload["cleanup_ttl_seconds"] = options.cleanup_ttl_seconds
+    if options.cleanup_limit is not None:
+        if options.cleanup_limit < 1:
+            print("Error: --cleanup-limit must be at least 1", file=sys.stderr)
+            sys.exit(1)
+        policy_payload["cleanup_limit"] = options.cleanup_limit
+    if options.detach_mode is not None:
+        policy_payload["detach_mode"] = options.detach_mode
+    if options.detach_min_age is not None:
+        policy_payload["detach_min_age"] = options.detach_min_age
+
+    print_verbose_configuration(
+        options.verbose,
+        [("Queue", queue_name)] + get_common_db_details(config),
+    )
+
+    if policy_payload:
+        if options.verbose:
+            print(f"Updating queue policy for '{queue_name}'...")
+        run_psql(
+            config,
+            "SELECT absurd.set_queue_policy(:'queue_name', :'policy_json'::jsonb);",
+            variables={
+                "queue_name": queue_name,
+                "policy_json": json.dumps(policy_payload),
+            },
+        )
+
+    policy = _fetch_queue_policy(config, queue_name)
+    if policy is None:
+        print(f"Queue '{queue_name}' does not have a policy record", file=sys.stderr)
+        sys.exit(1)
+
+    _print_queue_policy(policy)
+
+
+def cmd_cron(args):
+    """Enable or disable Absurd-managed pg_cron jobs."""
+    usage = "usage: %prog cron [options]"
+    parser = build_command_parser(usage)
+    parser.add_option(
+        "--enable",
+        dest="enable",
+        action="store_true",
+        default=False,
+        help="Enable Absurd cron jobs",
+    )
+    parser.add_option(
+        "--disable",
+        dest="disable",
+        action="store_true",
+        default=False,
+        help="Disable Absurd cron jobs",
+    )
+    parser.add_option(
+        "-q",
+        "--queue",
+        dest="queue",
+        metavar="NAME",
+        help="Queue scope (omit for global/all queues scope)",
+    )
+    parser.add_option(
+        "--partition-schedule",
+        dest="partition_schedule",
+        default="5 * * * *",
+        metavar="CRON",
+        help="Cron schedule for partition provisioning (default: '5 * * * *')",
+    )
+    parser.add_option(
+        "--cleanup-schedule",
+        dest="cleanup_schedule",
+        default="17 * * * *",
+        metavar="CRON",
+        help="Cron schedule for cleanup maintenance (default: '17 * * * *')",
+    )
+    parser.add_option(
+        "--detach-schedule",
+        dest="detach_schedule",
+        default="29 * * * *",
+        metavar="CRON",
+        help="Cron schedule for detach planning (default: '29 * * * *')",
+    )
+
+    examples = [
+        "absurdctl cron --enable",
+        "absurdctl cron --enable --queue myqueue",
+        "absurdctl cron --enable --queue myqueue --partition-schedule '*/15 * * * *'",
+        "absurdctl cron --disable",
+        "absurdctl cron --disable --queue myqueue",
+    ]
+
+    options, args = parse_args_with_help(parser, args, examples)
+
+    if args:
+        print("Error: cron does not accept positional arguments", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    if options.enable == options.disable:
+        print("Error: Provide exactly one of --enable or --disable", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    config = config_from_options(options)
+
+    if options.queue is not None:
+        options.queue = validate_queue_name(options.queue)
+
+    print_verbose_configuration(
+        options.verbose,
+        [
+            ("Action", "enable" if options.enable else "disable"),
+            ("Queue", options.queue or "all"),
+            ("Partition schedule", options.partition_schedule),
+            ("Cleanup schedule", options.cleanup_schedule),
+            ("Detach schedule", options.detach_schedule),
+        ]
+        + get_common_db_details(config),
+    )
+
+    if options.enable:
+        if options.queue is None:
+            query = """
+                SELECT job_name, job_id
+                FROM absurd.enable_cron(
+                  null::text,
+                  :'partition_schedule',
+                  :'cleanup_schedule',
+                  :'detach_schedule'
+                )
+                ORDER BY job_name
+            """
+            variables = {
+                "partition_schedule": options.partition_schedule,
+                "cleanup_schedule": options.cleanup_schedule,
+                "detach_schedule": options.detach_schedule,
+            }
+        else:
+            query = """
+                SELECT job_name, job_id
+                FROM absurd.enable_cron(
+                  :'queue_name',
+                  :'partition_schedule',
+                  :'cleanup_schedule',
+                  :'detach_schedule'
+                )
+                ORDER BY job_name
+            """
+            variables = {
+                "queue_name": options.queue,
+                "partition_schedule": options.partition_schedule,
+                "cleanup_schedule": options.cleanup_schedule,
+                "detach_schedule": options.detach_schedule,
+            }
+
+        rows = run_psql_csv(config, query, variables=variables)
+        if rows:
+            print("Enabled cron jobs:")
+            for row in rows:
+                if len(row) >= 2:
+                    print(f"  {row[0]} (job_id={row[1]})")
+        else:
+            print("No cron jobs were created")
+    else:
+        if options.queue is None:
+            query = """
+                SELECT job_name, job_id
+                FROM absurd.disable_cron(null::text)
+                ORDER BY job_name
+            """
+            variables = None
+        else:
+            query = """
+                SELECT job_name, job_id
+                FROM absurd.disable_cron(:'queue_name')
+                ORDER BY job_name
+            """
+            variables = {"queue_name": options.queue}
+
+        rows = run_psql_csv(config, query, variables=variables)
+        if rows:
+            print("Disabled cron jobs:")
+            for row in rows:
+                if len(row) >= 2:
+                    print(f"  {row[0]} (job_id={row[1]})")
+        else:
+            print("No matching cron jobs found")
+
+
+def cmd_list_detach_candidates(args):
+    """List partition detach candidates."""
+    usage = "usage: %prog list-detach-candidates [options]"
+    parser = build_command_parser(usage)
+    parser.add_option(
+        "-q",
+        "--queue",
+        dest="queue",
+        metavar="NAME",
+        help="Queue scope (optional)",
+    )
+    parser.add_option(
+        "--show-sql",
+        dest="show_sql",
+        action="store_true",
+        default=False,
+        help="Include raw detach/drop SQL in output",
+    )
+
+    examples = [
+        "absurdctl list-detach-candidates",
+        "absurdctl list-detach-candidates --queue myqueue",
+        "absurdctl list-detach-candidates --show-sql",
+    ]
+
+    options, args = parse_args_with_help(parser, args, examples)
+
+    if args:
+        print("Error: list-detach-candidates does not accept positional arguments", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    config = config_from_options(options)
+    variables = None
+    if options.queue is not None:
+        options.queue = validate_queue_name(options.queue)
+        variables = {"queue_name": options.queue}
+        query = """
+            SELECT
+              queue_name,
+              parent_table,
+              partition_table,
+              candidate_hash,
+              detach_sql,
+              drop_sql
+            FROM absurd.list_detach_candidates(:'queue_name')
+            ORDER BY queue_name, parent_table, partition_table
+        """
+    else:
+        query = """
+            SELECT
+              queue_name,
+              parent_table,
+              partition_table,
+              candidate_hash,
+              detach_sql,
+              drop_sql
+            FROM absurd.list_detach_candidates(null::text)
+            ORDER BY queue_name, parent_table, partition_table
+        """
+
+    rows = run_psql_csv(config, query, variables=variables)
+    if not rows:
+        print("No detach candidates found")
+        return
+
+    if not options.show_sql:
+        print("candidate_hash\tqueue\tparent\tpartition")
+        for row in rows:
+            if len(row) >= 4:
+                print(f"{row[3]}\t{row[0]}\t{row[1]}\t{row[2]}")
+        return
+
+    for row in rows:
+        if len(row) < 6:
+            continue
+        print(f"candidate_hash: {row[3]}")
+        print(f"  queue: {row[0]}")
+        print(f"  parent: {row[1]}")
+        print(f"  partition: {row[2]}")
+        print(f"  detach_sql: {row[4]}")
+        print(f"  drop_sql: {row[5]}")
+        print()
+
+
+def cmd_detach_candidate(args):
+    """Detach a specific candidate partition manually."""
+    usage = "usage: %prog detach-candidate [options] CANDIDATE_HASH"
+    parser = build_command_parser(usage)
+    parser.add_option(
+        "-q",
+        "--queue",
+        dest="queue",
+        metavar="NAME",
+        help="Queue scope (recommended when candidate hash is ambiguous)",
+    )
+    parser.add_option(
+        "--drop",
+        dest="drop",
+        action="store_true",
+        default=False,
+        help="Attempt immediate drop after detach via absurd.drop_detached_partition",
+    )
+
+    examples = [
+        "absurdctl detach-candidate 1a2b3c4d5e6f",
+        "absurdctl detach-candidate --queue myqueue 1a2b3c4d5e6f --drop",
+    ]
+
+    options, args = parse_args_with_help(parser, args, examples)
+
+    if len(args) != 1:
+        print("Error: Missing required argument CANDIDATE_HASH", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    candidate_hash = args[0].strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{12}", candidate_hash):
+        print("Error: CANDIDATE_HASH must be a 12-character lowercase hex digest", file=sys.stderr)
+        sys.exit(1)
+
+    config = config_from_options(options)
+    variables = {"candidate_hash": candidate_hash}
+    if options.queue is not None:
+        options.queue = validate_queue_name(options.queue)
+        variables["queue_name"] = options.queue
+        query = """
+            SELECT
+              queue_name,
+              parent_table,
+              partition_table,
+              candidate_hash,
+              detach_sql,
+              drop_sql
+            FROM absurd.list_detach_candidates(:'queue_name')
+            WHERE candidate_hash = :'candidate_hash'
+            ORDER BY queue_name, parent_table, partition_table
+        """
+    else:
+        query = """
+            SELECT
+              queue_name,
+              parent_table,
+              partition_table,
+              candidate_hash,
+              detach_sql,
+              drop_sql
+            FROM absurd.list_detach_candidates(null::text)
+            WHERE candidate_hash = :'candidate_hash'
+            ORDER BY queue_name, parent_table, partition_table
+        """
+
+    rows = run_psql_csv(config, query, variables=variables)
+    if not rows:
+        print(f"No detach candidate found for hash {candidate_hash}", file=sys.stderr)
+        sys.exit(1)
+
+    if len(rows) > 1:
+        print(
+            "Error: Candidate hash is ambiguous across queues; rerun with --queue",
+            file=sys.stderr,
+        )
+        for row in rows:
+            if len(row) >= 3:
+                print(f"  {row[0]} {row[1]} {row[2]}", file=sys.stderr)
+        sys.exit(1)
+
+    row = rows[0]
+    queue_name, parent_table, partition_table, _, detach_sql, _drop_sql = row
+
+    print(f"Detaching candidate {candidate_hash}:")
+    print(f"  queue: {queue_name}")
+    print(f"  parent: {parent_table}")
+    print(f"  partition: {partition_table}")
+    run_psql(config, detach_sql + ";")
+    print("Detach succeeded")
+
+    if options.drop:
+        dropped = run_psql(
+            config,
+            "SELECT absurd.drop_detached_partition(:'partition_table');",
+            tuples_only=True,
+            no_align=True,
+            variables={"partition_table": partition_table},
+        )
+        if dropped.strip() == "t":
+            print("Drop succeeded")
+        else:
+            print("Partition detached but not dropped yet")
 
 
 def cmd_init(args):
@@ -2339,6 +2866,10 @@ Commands:
   schema-version  Show the recorded Absurd schema version
   cleanup         Clean up old completed, failed, or cancelled tasks and events
   create-queue    Create a new queue
+  queue-policy    Get or update queue maintenance policy
+  cron            Enable or disable Absurd-managed pg_cron jobs
+  list-detach-candidates  List eligible partition detach candidates
+  detach-candidate        Detach one candidate partition manually
   drop-queue      Drop an existing queue
   list-queues     List all existing queues
   spawn-task      Spawn a new task
@@ -2366,7 +2897,11 @@ Examples:
   absurdctl migrate
   absurdctl schema-version
   absurdctl cleanup myqueue 30
-  absurdctl create-queue myqueue
+  absurdctl create-queue myqueue --storage-mode partitioned
+  absurdctl queue-policy myqueue --cleanup-ttl-seconds 604800
+  absurdctl cron --enable --queue myqueue
+  absurdctl list-detach-candidates --queue myqueue
+  absurdctl detach-candidate --queue myqueue 1a2b3c4d5e6f --drop
   absurdctl drop-queue myqueue --yes
   absurdctl list-queues
   absurdctl spawn-task my-task -P foo=bar -P count:=42
@@ -2396,6 +2931,14 @@ def main():
         cmd_schema_version(args)
     elif command == "create-queue":
         cmd_create_queue(args)
+    elif command == "queue-policy":
+        cmd_queue_policy(args)
+    elif command == "cron":
+        cmd_cron(args)
+    elif command == "list-detach-candidates":
+        cmd_list_detach_candidates(args)
+    elif command == "detach-candidate":
+        cmd_detach_candidate(args)
     elif command == "drop-queue":
         cmd_drop_queue(args)
     elif command == "list-queues":

--- a/absurdctl
+++ b/absurdctl
@@ -82,21 +82,17 @@ def normalize_partition_table_name(value):
         print("Error: Partition table must be provided.", file=sys.stderr)
         sys.exit(1)
 
-    if partition_table.lower().startswith("absurd."):
-        partition_table = partition_table.split(".", 1)[1]
+    lower_partition_table = partition_table.lower()
+    if lower_partition_table.startswith("absurd."):
+        partition_table = partition_table[len("absurd.") :]
+    elif lower_partition_table.startswith('"absurd".'):
+        partition_table = partition_table[len('"absurd".') :]
 
     if partition_table.startswith('"') and partition_table.endswith('"'):
         partition_table = partition_table[1:-1].replace('""', '"')
 
     if not partition_table:
         print("Error: Partition table must be provided.", file=sys.stderr)
-        sys.exit(1)
-
-    if "." in partition_table:
-        print(
-            "Error: PARTITION_TABLE must be an unqualified table name in schema absurd.",
-            file=sys.stderr,
-        )
         sys.exit(1)
 
     return partition_table

--- a/absurdctl
+++ b/absurdctl
@@ -98,6 +98,39 @@ def normalize_partition_table_name(value):
     return partition_table
 
 
+def build_drop_partition_sql(partition_table):
+    return f"drop table if exists absurd.{quote_ident(partition_table)}"
+
+
+def build_detach_partition_sql(config, parent_table, partition_table):
+    has_default = run_psql(
+        config,
+        """
+        select exists (
+          select 1
+          from pg_class parent
+          join pg_namespace pn on pn.oid = parent.relnamespace
+          join pg_inherits inh on inh.inhparent = parent.oid
+          join pg_class child on child.oid = inh.inhrelid
+          where pn.nspname = 'absurd'
+            and parent.relname = :'parent_table'
+            and pg_get_expr(child.relpartbound, child.oid) = 'DEFAULT'
+        )
+        """,
+        tuples_only=True,
+        no_align=True,
+        variables={"parent_table": parent_table},
+    ).strip()
+
+    sql = (
+        f"alter table absurd.{quote_ident(parent_table)} "
+        f"detach partition absurd.{quote_ident(partition_table)}"
+    )
+    if has_default != "t":
+        sql += " concurrently"
+    return sql
+
+
 class RemoteMigrationDiscoveryError(Exception):
     pass
 
@@ -1399,9 +1432,7 @@ def cmd_list_detach_candidates(args):
             SELECT
               queue_name,
               parent_table,
-              partition_table,
-              detach_sql,
-              drop_sql
+              partition_table
             FROM absurd.list_detach_candidates(:'queue_name')
             ORDER BY queue_name, parent_table, partition_table
         """
@@ -1410,9 +1441,7 @@ def cmd_list_detach_candidates(args):
             SELECT
               queue_name,
               parent_table,
-              partition_table,
-              detach_sql,
-              drop_sql
+              partition_table
             FROM absurd.list_detach_candidates(null::text)
             ORDER BY queue_name, parent_table, partition_table
         """
@@ -1430,13 +1459,15 @@ def cmd_list_detach_candidates(args):
         return
 
     for row in rows:
-        if len(row) < 5:
+        if len(row) < 3:
             continue
+        detach_sql = build_detach_partition_sql(config, row[1], row[2])
+        drop_sql = build_drop_partition_sql(row[2])
         print(f"  queue: {row[0]}")
         print(f"  parent: {row[1]}")
         print(f"  partition: {row[2]}")
-        print(f"  detach_sql: {row[3]}")
-        print(f"  drop_sql: {row[4]}")
+        print(f"  detach_sql: {detach_sql}")
+        print(f"  drop_sql: {drop_sql}")
         print()
 
 
@@ -1482,9 +1513,7 @@ def cmd_detach_candidate(args):
             SELECT
               queue_name,
               parent_table,
-              partition_table,
-              detach_sql,
-              drop_sql
+              partition_table
             FROM absurd.list_detach_candidates(:'queue_name')
             WHERE partition_table = :'partition_table'
             ORDER BY queue_name, parent_table, partition_table
@@ -1494,9 +1523,7 @@ def cmd_detach_candidate(args):
             SELECT
               queue_name,
               parent_table,
-              partition_table,
-              detach_sql,
-              drop_sql
+              partition_table
             FROM absurd.list_detach_candidates(null::text)
             WHERE partition_table = :'partition_table'
             ORDER BY queue_name, parent_table, partition_table
@@ -1518,7 +1545,8 @@ def cmd_detach_candidate(args):
         sys.exit(1)
 
     row = rows[0]
-    queue_name, parent_table, partition_table, detach_sql, _drop_sql = row
+    queue_name, parent_table, partition_table = row
+    detach_sql = build_detach_partition_sql(config, parent_table, partition_table)
 
     print(f"Detaching partition {partition_table}:")
     print(f"  queue: {queue_name}")

--- a/absurdctl
+++ b/absurdctl
@@ -57,7 +57,7 @@ def queue_relation(prefix, queue_name):
 
 def validate_queue_name(value):
     """Validate queue names used in dynamic table/index names."""
-    if value is None or len(value.strip()) == 0:
+    if value is None or value == "":
         print("Error: Queue name must be provided.", file=sys.stderr)
         sys.exit(1)
 
@@ -2147,7 +2147,7 @@ def cmd_list_tasks(args):
         print("No queues found in the database", file=sys.stderr)
         sys.exit(0)
 
-    queues = [q for q in queues_result.strip().split("\n") if q]
+    queues = [q for q in queues_result.splitlines() if q != ""]
 
     # Filter to specific queue if requested
     if options.queue:
@@ -2408,7 +2408,7 @@ def cmd_dump_task(args):
         print("No queues found in the database", file=sys.stderr)
         sys.exit(1)
 
-    queues = [q for q in queues_result.strip().split("\n") if q]
+    queues = [q for q in queues_result.splitlines() if q != ""]
 
     # Find which queue contains the task/run
     target_queue = None

--- a/absurdctl
+++ b/absurdctl
@@ -71,6 +71,37 @@ def validate_queue_name(value):
     return value
 
 
+def normalize_partition_table_name(value):
+    """Normalize a partition table reference to an absurd-schema table name."""
+    if value is None:
+        print("Error: Partition table must be provided.", file=sys.stderr)
+        sys.exit(1)
+
+    partition_table = value.strip()
+    if not partition_table:
+        print("Error: Partition table must be provided.", file=sys.stderr)
+        sys.exit(1)
+
+    if partition_table.lower().startswith("absurd."):
+        partition_table = partition_table.split(".", 1)[1]
+
+    if partition_table.startswith('"') and partition_table.endswith('"'):
+        partition_table = partition_table[1:-1].replace('""', '"')
+
+    if not partition_table:
+        print("Error: Partition table must be provided.", file=sys.stderr)
+        sys.exit(1)
+
+    if "." in partition_table:
+        print(
+            "Error: PARTITION_TABLE must be an unqualified table name in schema absurd.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return partition_table
+
+
 class RemoteMigrationDiscoveryError(Exception):
     pass
 
@@ -1359,7 +1390,6 @@ def cmd_list_detach_candidates(args):
               queue_name,
               parent_table,
               partition_table,
-              candidate_hash,
               detach_sql,
               drop_sql
             FROM absurd.list_detach_candidates(:'queue_name')
@@ -1371,7 +1401,6 @@ def cmd_list_detach_candidates(args):
               queue_name,
               parent_table,
               partition_table,
-              candidate_hash,
               detach_sql,
               drop_sql
             FROM absurd.list_detach_candidates(null::text)
@@ -1384,34 +1413,33 @@ def cmd_list_detach_candidates(args):
         return
 
     if not options.show_sql:
-        print("candidate_hash\tqueue\tparent\tpartition")
+        print("partition\tqueue\tparent")
         for row in rows:
-            if len(row) >= 4:
-                print(f"{row[3]}\t{row[0]}\t{row[1]}\t{row[2]}")
+            if len(row) >= 3:
+                print(f"{row[2]}\t{row[0]}\t{row[1]}")
         return
 
     for row in rows:
-        if len(row) < 6:
+        if len(row) < 5:
             continue
-        print(f"candidate_hash: {row[3]}")
         print(f"  queue: {row[0]}")
         print(f"  parent: {row[1]}")
         print(f"  partition: {row[2]}")
-        print(f"  detach_sql: {row[4]}")
-        print(f"  drop_sql: {row[5]}")
+        print(f"  detach_sql: {row[3]}")
+        print(f"  drop_sql: {row[4]}")
         print()
 
 
 def cmd_detach_candidate(args):
     """Detach a specific candidate partition manually."""
-    usage = "usage: %prog detach-candidate [options] CANDIDATE_HASH"
+    usage = "usage: %prog detach-candidate [options] PARTITION_TABLE"
     parser = build_command_parser(usage)
     parser.add_option(
         "-q",
         "--queue",
         dest="queue",
         metavar="NAME",
-        help="Queue scope (recommended when candidate hash is ambiguous)",
+        help="Queue scope (optional)",
     )
     parser.add_option(
         "--drop",
@@ -1422,24 +1450,21 @@ def cmd_detach_candidate(args):
     )
 
     examples = [
-        "absurdctl detach-candidate 1a2b3c4d5e6f",
-        "absurdctl detach-candidate --queue myqueue 1a2b3c4d5e6f --drop",
+        "absurdctl detach-candidate t_myqueue_2414",
+        "absurdctl detach-candidate --queue myqueue t_myqueue_2414 --drop",
     ]
 
     options, args = parse_args_with_help(parser, args, examples)
 
     if len(args) != 1:
-        print("Error: Missing required argument CANDIDATE_HASH", file=sys.stderr)
+        print("Error: Missing required argument PARTITION_TABLE", file=sys.stderr)
         parser.print_help()
         sys.exit(1)
 
-    candidate_hash = args[0].strip().lower()
-    if not re.fullmatch(r"[0-9a-f]{12}", candidate_hash):
-        print("Error: CANDIDATE_HASH must be a 12-character lowercase hex digest", file=sys.stderr)
-        sys.exit(1)
+    partition_table = normalize_partition_table_name(args[0])
 
     config = config_from_options(options)
-    variables = {"candidate_hash": candidate_hash}
+    variables = {"partition_table": partition_table}
     if options.queue is not None:
         options.queue = validate_queue_name(options.queue)
         variables["queue_name"] = options.queue
@@ -1448,11 +1473,10 @@ def cmd_detach_candidate(args):
               queue_name,
               parent_table,
               partition_table,
-              candidate_hash,
               detach_sql,
               drop_sql
             FROM absurd.list_detach_candidates(:'queue_name')
-            WHERE candidate_hash = :'candidate_hash'
+            WHERE partition_table = :'partition_table'
             ORDER BY queue_name, parent_table, partition_table
         """
     else:
@@ -1461,22 +1485,21 @@ def cmd_detach_candidate(args):
               queue_name,
               parent_table,
               partition_table,
-              candidate_hash,
               detach_sql,
               drop_sql
             FROM absurd.list_detach_candidates(null::text)
-            WHERE candidate_hash = :'candidate_hash'
+            WHERE partition_table = :'partition_table'
             ORDER BY queue_name, parent_table, partition_table
         """
 
     rows = run_psql_csv(config, query, variables=variables)
     if not rows:
-        print(f"No detach candidate found for hash {candidate_hash}", file=sys.stderr)
+        print(f"No detach candidate found for partition {partition_table}", file=sys.stderr)
         sys.exit(1)
 
     if len(rows) > 1:
         print(
-            "Error: Candidate hash is ambiguous across queues; rerun with --queue",
+            "Error: Partition table is ambiguous across queues; rerun with --queue",
             file=sys.stderr,
         )
         for row in rows:
@@ -1485,9 +1508,9 @@ def cmd_detach_candidate(args):
         sys.exit(1)
 
     row = rows[0]
-    queue_name, parent_table, partition_table, _, detach_sql, _drop_sql = row
+    queue_name, parent_table, partition_table, detach_sql, _drop_sql = row
 
-    print(f"Detaching candidate {candidate_hash}:")
+    print(f"Detaching partition {partition_table}:")
     print(f"  queue: {queue_name}")
     print(f"  parent: {parent_table}")
     print(f"  partition: {partition_table}")
@@ -2897,7 +2920,7 @@ Examples:
   absurdctl queue-policy myqueue --cleanup-ttl '7 days'
   absurdctl cron --enable --queue myqueue
   absurdctl list-detach-candidates --queue myqueue
-  absurdctl detach-candidate --queue myqueue 1a2b3c4d5e6f --drop
+  absurdctl detach-candidate --queue myqueue t_myqueue_2414 --drop
   absurdctl drop-queue myqueue --yes
   absurdctl list-queues
   absurdctl spawn-task my-task -P foo=bar -P count:=42

--- a/absurdctl
+++ b/absurdctl
@@ -1047,6 +1047,7 @@ def _fetch_queue_policy(config, queue_name):
         SELECT
           queue_name,
           storage_mode,
+          default_partition,
           partition_lookahead::text,
           partition_lookback::text,
           cleanup_ttl::text,
@@ -1061,24 +1062,26 @@ def _fetch_queue_policy(config, queue_name):
         return None
 
     parts = rows[0]
-    if len(parts) < 8:
+    if len(parts) < 9:
         return None
 
     return {
         "queue_name": parts[0],
         "storage_mode": parts[1],
-        "partition_lookahead": parts[2],
-        "partition_lookback": parts[3],
-        "cleanup_ttl": parts[4],
-        "cleanup_limit": parts[5],
-        "detach_mode": parts[6],
-        "detach_min_age": parts[7],
+        "default_partition": parts[2],
+        "partition_lookahead": parts[3],
+        "partition_lookback": parts[4],
+        "cleanup_ttl": parts[5],
+        "cleanup_limit": parts[6],
+        "detach_mode": parts[7],
+        "detach_min_age": parts[8],
     }
 
 
 def _print_queue_policy(policy):
     print(f"Queue policy for '{policy['queue_name']}':")
     print(f"  storage_mode: {policy['storage_mode']}")
+    print(f"  default_partition: {policy['default_partition']}")
     print(f"  partition_lookahead: {policy['partition_lookahead']}")
     print(f"  partition_lookback: {policy['partition_lookback']}")
     print(f"  cleanup_ttl: {policy['cleanup_ttl']}")
@@ -1091,6 +1094,14 @@ def cmd_queue_policy(args):
     """Get or update queue maintenance policy."""
     usage = "usage: %prog queue-policy [options] QUEUE_NAME"
     parser = build_command_parser(usage)
+    parser.add_option(
+        "--default-partition",
+        dest="default_partition",
+        type="choice",
+        choices=["enabled", "disabled"],
+        metavar="MODE",
+        help="Default partition mode for partitioned queues (enabled or disabled)",
+    )
     parser.add_option(
         "--partition-lookahead",
         dest="partition_lookahead",
@@ -1134,6 +1145,7 @@ def cmd_queue_policy(args):
     examples = [
         "absurdctl queue-policy myqueue",
         "absurdctl queue-policy myqueue --cleanup-ttl '30 days' --cleanup-limit 2000",
+        "absurdctl queue-policy myqueue --default-partition disabled",
         "absurdctl queue-policy myqueue --partition-lookahead '42 days' --partition-lookback '2 days'",
         "absurdctl queue-policy myqueue --detach-mode empty --detach-min-age '30 days'",
     ]
@@ -1150,6 +1162,8 @@ def cmd_queue_policy(args):
     ensure_queue_exists(config, queue_name)
 
     policy_payload = {}
+    if options.default_partition is not None:
+        policy_payload["default_partition"] = options.default_partition
     if options.partition_lookahead is not None:
         policy_payload["partition_lookahead"] = options.partition_lookahead
     if options.partition_lookback is not None:

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,177 +1,104 @@
 # Cleanup and Retention
 
-Absurd keeps task history and event data in Postgres until you delete it.
+Absurd keeps task history and events in Postgres until you remove them.
 
-That is useful for debugging and inspection, but it also means you need a
-retention plan.  Otherwise old runs, checkpoints, waits, and events will simply
-accumulate forever.
+Cleanup works by setting a retention policy per queue which is then used by
+the maintenance commands.  It works like this:
 
-This page explains what cleanup removes, how to do it with
-[`absurdctl`](./tools/absurdctl.md), how to call the stored procedures directly, and
-how to automate retention with real cron jobs or with an Absurd task of your
-own.
+1. set retention policy per queue
+2. run policy-aware cleanup for all queues
+3. (for partitioned queues) combine row cleanup with partition lifecycle jobs (see below)
 
-## What Cleanup Removes
+This page gives the high-level operating model and links to command details.
 
-Absurd exposes two cleanup functions in SQL:
+## Cleanup Is Policy-Driven Per Queue
 
+Each queue has retention policy fields in `absurd.queues`, including:
+
+- `cleanup_ttl`
+- `cleanup_limit`
+
+You usually manage these with:
+
+```bash
+absurdctl queue-policy <queue> --cleanup-ttl '30 days' --cleanup-limit 1000
+```
+
+Once policy is set, cleanup tasks will honor it:
+
+```sql
+select * from absurd.cleanup_all_queues();
+```
+
+That function applies each queue's own policy, so different queues can keep
+history for different durations without separate scripts per queue.
+
+See also:
+
+- **[Storage](./storage.md)** for full policy fields (including partition policy)
+- **[absurdctl](./tools/absurdctl.md)** for queue-policy command options
+
+## Queue-Specific Cleanup
+
+Queue-targeted cleanup is available for ad-hoc use:
+
+- `absurdctl cleanup <queue> <ttl_days>`
 - `absurd.cleanup_tasks(queue, ttl_seconds, limit)`
 - `absurd.cleanup_events(queue, ttl_seconds, limit)`
 
-### Task cleanup
+## Partitioned Queue Lifecycle
 
-`absurd.cleanup_tasks` deletes **terminal** tasks older than the TTL:
+For partitioned queues, cleanup is only one piece of retention.
 
-- `completed`
-- `failed`
-- `cancelled`
+A complete lifecycle is:
 
-It also deletes their related:
+1. **Provision partitions ahead of time** with `absurd.ensure_partitions(...)`
+2. **Delete old rows** with policy-driven cleanup (`absurd.cleanup_all_queues(...)`)
+3. **Plan and execute detach/drop** for old empty partitions
 
-- wait registrations
-- checkpoints
-- runs
-- the task row itself
+Partition detach/drop is controlled by queue policy (`detach_mode`,
+`detach_min_age`) and is operationally separate from row deletion with the
+help of `DETACH PARTITION ... CONCURRENTLY`.
 
-It does **not** delete tasks that are still pending, running, or sleeping.
+For details, see:
 
-### Event cleanup
+- **[Storage](./storage.md#detaching-old-empty-partitions)**
+- **[absurdctl](./tools/absurdctl.md#partition-detach-operations)**
 
-`absurd.cleanup_events` deletes emitted events older than the TTL.
+## Cron-Driven Maintenance
 
-## The Easiest Option: `absurdctl cleanup`
-
-If you just want a simple retention job, use `absurdctl cleanup`.
-It cleans up both old terminal tasks and old events for the target queue.
+If `pg_cron` is available, let Absurd manage recurring maintenance jobs:
 
 ```bash
-absurdctl cleanup default 7
+# all queues
+absurdctl cron --enable
+
+# queue-scoped schedules
+absurdctl cron --enable --queue jobs \
+  --partition-schedule '*/15 * * * *' \
+  --cleanup-schedule '7 * * * *' \
+  --detach-schedule '29 * * * *'
 ```
 
-That means:
+Under the hood, this schedules:
 
-- queue: `default`
-- retention: `7` days
+- partition provisioning (`ensure_partitions`)
+- policy-driven cleanup (`cleanup_all_queues`)
+- detach planning (`schedule_detach_jobs`)
 
-A couple more examples:
-
-```bash
-absurdctl cleanup emails 30
-absurdctl cleanup reports 90
-```
-
-This is the best choice when:
-
-- you already have shell access to the machine
-- you want one simple command in cron
-- "days" is good enough as your retention unit
-
-## Direct SQL Cleanup
-
-If you want finer control, call the stored procedures directly.
-
-Unlike `absurdctl cleanup`, the SQL functions take TTL in **seconds** and let
-you control the **batch size** explicitly.
-
-```sql
-select absurd.cleanup_tasks('default', 7 * 86400, 1000);
-select absurd.cleanup_events('default', 7 * 86400, 1000);
-```
-
-The third argument is the maximum number of rows to delete in one call.
-
-This is useful when:
-
-- you want to run cleanup from your own application code
-- you want second-level retention control
-- you want to batch large deletions more carefully
-
-## Batching Large Cleanups
-
-If you have a lot of old data, it can be better to delete it in chunks.
-
-For example, in `psql`:
-
-```sql
-select absurd.cleanup_tasks('default', 30 * 86400, 1000);
-select absurd.cleanup_events('default', 30 * 86400, 1000);
-```
-
-Then run those repeatedly until they return `0`.
-
-A simple shell loop looks like this:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-QUEUE="default"
-TTL_SECONDS=$((30 * 86400))
-LIMIT=1000
-
-while true; do
-  deleted_tasks=$(psql "$PGDATABASE" -Atqc \
-    "select absurd.cleanup_tasks('${QUEUE}', ${TTL_SECONDS}, ${LIMIT})")
-  deleted_events=$(psql "$PGDATABASE" -Atqc \
-    "select absurd.cleanup_events('${QUEUE}', ${TTL_SECONDS}, ${LIMIT})")
-
-  echo "deleted tasks=${deleted_tasks} events=${deleted_events}"
-
-  if [ "$deleted_tasks" = "0" ] && [ "$deleted_events" = "0" ]; then
-    break
-  fi
-
-done
-```
-
-That pattern is handy when you are cleaning up a backlog for the first time.
-
-## Real Cron Jobs with `absurdctl`
-
-For most deployments, the simplest production setup is an ordinary OS cron job.
-
-Run every day at 03:17:
-
-```cron
-PGDATABASE=postgresql://user:pass@db/app
-17 3 * * * absurdctl cleanup default 30 >> /var/log/absurd-cleanup.log 2>&1
-```
-
-For multiple queues, use a wrapper script:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-export PGDATABASE="postgresql://user:pass@db/app"
-
-absurdctl cleanup default 30
-absurdctl cleanup emails 90
-absurdctl cleanup reports 14
-```
-
-And then schedule that script:
-
-```cron
-17 3 * * * /srv/app/bin/absurd-retention.sh >> /var/log/absurd-cleanup.log 2>&1
-```
-
-This is usually the right answer if you do not need cleanup itself to be a
-workflow.
+This gives one coherent database-native maintenance loop for both
+unpartitioned and partitioned queues.
 
 ## Using an Absurd Task for Cleanup
 
-If you want cleanup to be observable in Habitat, retryable, and recorded like
-other work, you can wrap it in an Absurd task.
+If you want cleanup to be visible in Habitat and retried like regular work,
+you can wrap cleanup calls in an Absurd task.
 
-A practical way to do that is:
+This is also a good option when you do not use `pg_cron`: you can trigger
+this task from any external scheduler (OS cron, systemd timer, CI, Kubernetes
+CronJob, etc.) or run a one-off manual trigger script.
 
-1. register a `cleanup-retention` task
-2. call the SQL cleanup functions inside steps using your normal Postgres client
-3. schedule that task from cron or another scheduler
-4. use a daily idempotency key so duplicate cron runs collapse into one task
-
-### Example: cleanup task
+### Example cleanup task
 
 === "TypeScript"
 
@@ -258,112 +185,9 @@ A practical way to do that is:
     app.start_worker()
     ```
 
-=== "Go"
+### Manual trigger script (no `pg_cron` required)
 
-    ```go
-    package main
-
-    import (
-        "context"
-        "database/sql"
-        "log"
-        "os"
-
-        "github.com/earendil-works/absurd/sdks/go/absurd"
-    )
-
-    type CleanupParams struct {
-        TargetQueue string `json:"target_queue"`
-        TTLDays     int    `json:"ttl_days"`
-        Limit       int    `json:"limit"`
-    }
-
-    type CleanupResult struct {
-        TargetQueue   string `json:"target_queue"`
-        TTLDays       int    `json:"ttl_days"`
-        DeletedTasks  int    `json:"deleted_tasks"`
-        DeletedEvents int    `json:"deleted_events"`
-    }
-
-    func main() {
-        db, err := sql.Open("postgres", os.Getenv("PGDATABASE"))
-        if err != nil {
-            log.Fatal(err)
-        }
-        defer db.Close()
-
-        app, err := absurd.New(absurd.Options{DB: db, QueueName: "ops"})
-        if err != nil {
-            log.Fatal(err)
-        }
-        defer app.Close()
-
-        app.MustRegister(absurd.Task(
-            "cleanup-retention",
-            func(
-                ctx context.Context,
-                params CleanupParams,
-            ) (CleanupResult, error) {
-                ttlSeconds := params.TTLDays * 86400
-                limit := params.Limit
-                if limit == 0 {
-                    limit = 1000
-                }
-
-                deletedTasks, err := absurd.Step(
-                    ctx,
-                    "cleanup-tasks",
-                    func(ctx context.Context) (int, error) {
-                        var deleted int
-                        err := db.QueryRowContext(
-                            ctx,
-                            "select absurd.cleanup_tasks($1, $2, $3)",
-                            params.TargetQueue,
-                            ttlSeconds,
-                            limit,
-                        ).Scan(&deleted)
-                        return deleted, err
-                    },
-                )
-                if err != nil {
-                    return CleanupResult{}, err
-                }
-
-                deletedEvents, err := absurd.Step(
-                    ctx,
-                    "cleanup-events",
-                    func(ctx context.Context) (int, error) {
-                        var deleted int
-                        err := db.QueryRowContext(
-                            ctx,
-                            "select absurd.cleanup_events($1, $2, $3)",
-                            params.TargetQueue,
-                            ttlSeconds,
-                            limit,
-                        ).Scan(&deleted)
-                        return deleted, err
-                    },
-                )
-                if err != nil {
-                    return CleanupResult{}, err
-                }
-
-                return CleanupResult{
-                    TargetQueue:   params.TargetQueue,
-                    TTLDays:       params.TTLDays,
-                    DeletedTasks:  deletedTasks,
-                    DeletedEvents: deletedEvents,
-                }, nil
-            },
-        ))
-
-        if err := app.RunWorker(context.Background()); err != nil {
-            log.Fatal(err)
-        }
-    }
-    ```
-
-And a small script that enqueues it once per day:
+You can enqueue one cleanup task per day with an idempotency key.
 
 === "TypeScript"
 
@@ -420,112 +244,24 @@ And a small script that enqueues it once per day:
     conn.close()
     ```
 
-=== "Go"
+Then schedule that script in your existing scheduler, for example:
 
-    ```go
-    package main
+```cron
+PGDATABASE=postgresql://user:pass@db/app
+17 3 * * * uv run /srv/app/bin/spawn-cleanup.py
+```
 
-    import (
-        "context"
-        "database/sql"
-        "fmt"
-        "log"
-        "os"
-        "time"
+This model gives a simple split of responsibilities:
 
-        "github.com/earendil-works/absurd/sdks/go/absurd"
-    )
+- external scheduler decides **when** cleanup should run
+- Absurd records **that** cleanup ran, including retries and step history
 
-    type CleanupParams struct {
-        TargetQueue string `json:"target_queue"`
-        TTLDays     int    `json:"ttl_days"`
-        Limit       int    `json:"limit"`
-    }
+## Practical Model by Storage Mode
 
-    func main() {
-        db, err := sql.Open("postgres", os.Getenv("PGDATABASE"))
-        if err != nil {
-            log.Fatal(err)
-        }
-        defer db.Close()
+- **Unpartitioned queues**: set `cleanup_ttl`/`cleanup_limit`, then run cron
+  cleanup (`cleanup_all_queues`).
+- **Partitioned queues**: same cleanup policy, plus partition provisioning and
+  detach/drop planning.
 
-        app, err := absurd.New(absurd.Options{DB: db, QueueName: "ops"})
-        if err != nil {
-            log.Fatal(err)
-        }
-        defer app.Close()
-
-        day := time.Now().UTC().Format("2006-01-02")
-
-        _, err = app.Spawn(
-            context.Background(),
-            "cleanup-retention",
-            CleanupParams{
-                TargetQueue: "default",
-                TTLDays:     30,
-                Limit:       1000,
-            },
-            absurd.SpawnOptions{
-                IdempotencyKey: fmt.Sprintf("cleanup:default:%s", day),
-            },
-        )
-        if err != nil {
-            log.Fatal(err)
-        }
-    }
-    ```
-
-Then run that enqueue script from cron:
-
-=== "TypeScript"
-
-    ```cron
-    PGDATABASE=postgresql://user:pass@db/app
-    17 3 * * * node /srv/app/bin/spawn-cleanup.js
-    ```
-
-=== "Python"
-
-    ```cron
-    PGDATABASE=postgresql://user:pass@db/app
-    17 3 * * * uv run /srv/app/bin/spawn-cleanup.py
-    ```
-
-=== "Go"
-
-    ```cron
-    PGDATABASE=postgresql://user:pass@db/app
-    17 3 * * * /srv/app/bin/spawn-cleanup
-    ```
-
-This example handles one cleanup batch per task run.  For steady-state daily
-retention that is often enough.  If you are draining a large backlog, prefer the
-SQL batching loop above or enqueue multiple cleanup tasks until the deleted
-counts reach zero.
-
-That gives you a nice hybrid:
-
-- cron decides **when** cleanup should happen
-- Absurd records **that** cleanup happened and retries it if needed
-
-## Which Approach Should You Pick?
-
-A good rule of thumb:
-
-- use **`absurdctl cleanup`** if you want the simplest operational setup
-- use the **SQL functions directly** if you need tighter batching or want to integrate with existing app/database tooling
-- use an **Absurd cleanup task** if you want retention work to be tracked and retried like any other task
-
-## Suggested Retention Strategy
-
-Different queues often deserve different TTLs.
-
-For example:
-
-- `default`: 30 days
-- `emails`: 90 days
-- `reports`: 14 days
-- agent/debug-heavy queues: longer, if you rely on history for investigation
-
-The important part is not choosing the perfect number on day one.  The important
-part is choosing **some** number and automating it.
+If you only need one-off deletion, `absurdctl cleanup` is fine.
+If you need stable production retention, use queue policy + Absurd-managed cron.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -108,6 +108,15 @@ Postgres tables:
 
 Partitioned queues additionally have an `i_` table for idempotency key mapping.
 
+Each queue also carries a maintenance policy (stored in `absurd.queues`) for:
+
+- partition window provisioning (`partition_lookahead`, `partition_lookback`)
+- cleanup retention (`cleanup_ttl_seconds`, `cleanup_limit`)
+- optional detach planning (`detach_mode`, `detach_min_age`)
+
+`absurd.ensure_partitions()` and `absurd.cleanup_all_queues()` use this stored
+policy, which keeps runtime maintenance behavior consistent and inspectable.
+
 Queues let you scale workers independently and isolate different workloads.
 
 ## Workers

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -106,6 +106,8 @@ Postgres tables:
 | `e_`   | Events — emitted signals |
 | `w_`   | Wait registrations — tasks waiting for events |
 
+Partitioned queues additionally have an `i_` table for idempotency key mapping.
+
 Queues let you scale workers independently and isolate different workloads.
 
 ## Workers

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -111,11 +111,14 @@ Partitioned queues additionally have an `i_` table for idempotency key mapping.
 Each queue also carries a maintenance policy (stored in `absurd.queues`) for:
 
 - partition window provisioning (`partition_lookahead`, `partition_lookback`)
-- cleanup retention (`cleanup_ttl_seconds`, `cleanup_limit`)
+- cleanup retention (`cleanup_ttl`, `cleanup_limit`)
 - optional detach planning (`detach_mode`, `detach_min_age`)
 
 `absurd.ensure_partitions()` and `absurd.cleanup_all_queues()` use this stored
 policy, which keeps runtime maintenance behavior consistent and inspectable.
+
+For queue storage mode trade-offs (default vs partitioned), partition lifecycle,
+and `pg_cron` maintenance patterns, see **[Storage](./storage.md)**.
 
 Queues let you scale workers independently and isolate different workloads.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -191,6 +191,7 @@ them race-free.
 
 - **[Quickstart](./quickstart.md)** — install the schema, create a queue, run your first task
 - **[Concepts](./concepts.md)** — what durable execution is, plus tasks, steps, runs, events, and retry semantics
+- **[Storage](./storage.md)** — choose unpartitioned vs partitioned queues and automate partition lifecycle
 - **[Cleanup and Retention](./cleanup.md)** — set retention policies and automate cleanup with SQL, `absurdctl`, or cron
 - **[Comparison](./comparison.md)** — where Absurd fits relative to PGMQ, Cadence, Temporal, Inngest, and DBOS
 - **[Patterns](./patterns/)** — practical recipes for common workflow and scheduling setups

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,6 +22,7 @@ The exact examples in this guide live in the repository:
 ## Prerequisites
 
 - **PostgreSQL** (14 or later)
+- **`pg_cron` extension** *(optional, only needed if you want Absurd-managed cron automation for partition provisioning/cleanup/detach)*
 - **Node.js** with native TypeScript type stripping for the TypeScript SDK
 - **Python** (3.11+) with **`uv`** for the Python SDK
 - **Go** (1.25+) for the Go SDK

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -555,9 +555,44 @@ result, err := app.RetryTask(
 ## Queue Management
 
 ```go
+// Default storage mode is unpartitioned.
 if err := app.CreateQueue(ctx, "emails"); err != nil {
     log.Fatal(err)
 }
+
+// Create a partitioned queue.
+if err := app.CreateQueue(ctx, "emails-part", absurd.CreateQueueOptions{
+    StorageMode: absurd.QueueStoragePartitioned,
+}); err != nil {
+    log.Fatal(err)
+}
+
+// Configure policy at creation time.
+ttl := 90 * 86400
+limit := 2000
+if err := app.CreateQueue(ctx, "retained", absurd.CreateQueueOptions{
+    StorageMode: absurd.QueueStoragePartitioned,
+    QueuePolicyOptions: absurd.QueuePolicyOptions{
+        CleanupTTLSeconds:  &ttl,
+        CleanupLimit:       &limit,
+        PartitionLookahead: "42 days",
+        PartitionLookback:  "2 days",
+        DetachMode:         absurd.QueueDetachEmpty,
+        DetachMinAge:       "30 days",
+    },
+}); err != nil {
+    log.Fatal(err)
+}
+
+// Update/read policy later.
+newTTL := 60 * 86400
+if err := app.SetQueuePolicy(ctx, "retained", absurd.QueuePolicyOptions{
+    CleanupTTLSeconds: &newTTL,
+}); err != nil {
+    log.Fatal(err)
+}
+policy, err := app.GetQueuePolicy(ctx, "retained")
+
 if err := app.DropQueue(ctx, "emails"); err != nil {
     log.Fatal(err)
 }

--- a/docs/sdks/go.md
+++ b/docs/sdks/go.md
@@ -568,12 +568,12 @@ if err := app.CreateQueue(ctx, "emails-part", absurd.CreateQueueOptions{
 }
 
 // Configure policy at creation time.
-ttl := 90 * 86400
+ttl := "90 days"
 limit := 2000
 if err := app.CreateQueue(ctx, "retained", absurd.CreateQueueOptions{
     StorageMode: absurd.QueueStoragePartitioned,
     QueuePolicyOptions: absurd.QueuePolicyOptions{
-        CleanupTTLSeconds:  &ttl,
+        CleanupTTL:         ttl,
         CleanupLimit:       &limit,
         PartitionLookahead: "42 days",
         PartitionLookback:  "2 days",
@@ -585,9 +585,9 @@ if err := app.CreateQueue(ctx, "retained", absurd.CreateQueueOptions{
 }
 
 // Update/read policy later.
-newTTL := 60 * 86400
+newTTL := "60 days"
 if err := app.SetQueuePolicy(ctx, "retained", absurd.QueuePolicyOptions{
-    CleanupTTLSeconds: &newTTL,
+    CleanupTTL: newTTL,
 }); err != nil {
     log.Fatal(err)
 }

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -334,9 +334,38 @@ Returns a `RetryTaskResult` with `task_id`, `run_id`, `attempt`, `created`.
 ## Queue Management
 
 ```python
+# Default storage mode is unpartitioned
 app.create_queue("emails")
+
+# Explicit partitioned queue
+app.create_queue("emails-part", storage_mode="partitioned")
+
+# Configure policy at creation time
+app.create_queue(
+    "retained",
+    storage_mode="partitioned",
+    cleanup_ttl_seconds=90 * 86400,
+    cleanup_limit=2000,
+    partition_lookahead="42 days",
+    partition_lookback="2 days",
+    detach_mode="empty",
+    detach_min_age="30 days",
+)
+
+# Update/read policy later
+app.set_queue_policy("retained", cleanup_ttl_seconds=60 * 86400)
+policy = app.get_queue_policy("retained")
+
 app.drop_queue("emails")
-queues = app.list_queues()  # ["default", "emails"]
+queues = app.list_queues()
+```
+
+Async client methods are identical, but `await`ed:
+
+```python
+await app.create_queue("emails-part", storage_mode="partitioned")
+await app.set_queue_policy("emails-part", cleanup_limit=500)
+policy = await app.get_queue_policy("emails-part")
 ```
 
 ## Starting a Worker

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -344,7 +344,7 @@ app.create_queue("emails-part", storage_mode="partitioned")
 app.create_queue(
     "retained",
     storage_mode="partitioned",
-    cleanup_ttl_seconds=90 * 86400,
+    cleanup_ttl="90 days",
     cleanup_limit=2000,
     partition_lookahead="42 days",
     partition_lookback="2 days",
@@ -353,7 +353,7 @@ app.create_queue(
 )
 
 # Update/read policy later
-app.set_queue_policy("retained", cleanup_ttl_seconds=60 * 86400)
+app.set_queue_policy("retained", cleanup_ttl="60 days")
 policy = app.get_queue_policy("retained")
 
 app.drop_queue("emails")

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -279,9 +279,18 @@ const result = await app.retryTask(taskID, {
 ## Queue Management
 
 ```typescript
-await app.createQueue('emails');
+await app.createQueue('emails'); // default: unpartitioned
+await app.createQueue('emails-part', { storageMode: 'partitioned' });
+await app.createQueue('retained', {
+  cleanupTtlSeconds: 90 * 86400,
+  cleanupLimit: 2000,
+  partitionLookahead: '42 days',
+  partitionLookback: '2 days',
+  detachMode: 'empty',
+  detachMinAge: '30 days',
+});
 await app.dropQueue('emails');
-const queues = await app.listQueues(); // ['default', 'emails']
+const queues = await app.listQueues();
 ```
 
 ## Starting a Worker

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -286,7 +286,7 @@ await app.createQueue('emails-part', { storageMode: 'partitioned' });
 // Configure policy at creation time.
 await app.createQueue('retained', {
   storageMode: 'partitioned',
-  cleanupTtlSeconds: 90 * 86400,
+  cleanupTtl: '90 days',
   cleanupLimit: 2000,
   partitionLookahead: '42 days',
   partitionLookback: '2 days',
@@ -295,7 +295,7 @@ await app.createQueue('retained', {
 });
 
 // Update/read policy later.
-await app.setQueuePolicy('retained', { cleanupTtlSeconds: 60 * 86400 });
+await app.setQueuePolicy('retained', { cleanupTtl: '60 days' });
 const policy = await app.getQueuePolicy('retained'); // QueuePolicy | null
 
 await app.dropQueue('emails');

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -279,9 +279,13 @@ const result = await app.retryTask(taskID, {
 ## Queue Management
 
 ```typescript
+// queueName is optional and defaults to this client's queueName.
 await app.createQueue('emails'); // default: unpartitioned
 await app.createQueue('emails-part', { storageMode: 'partitioned' });
+
+// Configure policy at creation time.
 await app.createQueue('retained', {
+  storageMode: 'partitioned',
   cleanupTtlSeconds: 90 * 86400,
   cleanupLimit: 2000,
   partitionLookahead: '42 days',
@@ -289,8 +293,11 @@ await app.createQueue('retained', {
   detachMode: 'empty',
   detachMinAge: '30 days',
 });
+
+// Update/read policy later.
 await app.setQueuePolicy('retained', { cleanupTtlSeconds: 60 * 86400 });
-const policy = await app.getQueuePolicy('retained');
+const policy = await app.getQueuePolicy('retained'); // QueuePolicy | null
+
 await app.dropQueue('emails');
 const queues = await app.listQueues();
 ```

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -289,6 +289,8 @@ await app.createQueue('retained', {
   detachMode: 'empty',
   detachMinAge: '30 days',
 });
+await app.setQueuePolicy('retained', { cleanupTtlSeconds: 60 * 86400 });
+const policy = await app.getQueuePolicy('retained');
 await app.dropQueue('emails');
 const queues = await app.listQueues();
 ```

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -147,7 +147,10 @@ select absurd.cleanup_tasks('jobs', 30 * 86400, 1000);
 select absurd.cleanup_events('jobs', 30 * 86400, 1000);
 ```
 
-See also: **[Cleanup and Retention](./cleanup.md)**.
+See also:
+
+- **[Cleanup and Retention](./cleanup.md)** for the policy-driven model
+- **[absurdctl](./tools/absurdctl.md)** for operational commands
 
 ## Detaching Old Empty Partitions
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -70,6 +70,7 @@ mode.  If you try to recreate with a different mode, Absurd raises an error.
 
 Each queue has policy fields in `absurd.queues`:
 
+- `default_partition` (`enabled` or `disabled`, default `enabled`)
 - `partition_lookahead` (default `28 days`)
 - `partition_lookback` (default `1 day`)
 - `cleanup_ttl` (default `30 days`)
@@ -85,6 +86,7 @@ absurdctl queue-policy jobs
 
 # update
 absurdctl queue-policy jobs \
+  --default-partition enabled \
   --partition-lookahead '42 days' \
   --partition-lookback '2 days' \
   --cleanup-ttl '30 days' \
@@ -99,6 +101,7 @@ Equivalent SQL:
 select absurd.set_queue_policy(
   'jobs',
   '{
+    "default_partition": "enabled",
     "partition_lookahead": "42 days",
     "partition_lookback": "2 days",
     "cleanup_ttl": "30 days",
@@ -157,8 +160,8 @@ See also:
 For partitioned queues, Absurd supports policy-based detach planning:
 
 1. `absurd.list_detach_candidates(...)` finds old, empty weekly partitions.
-2. Those partitions can be detached with
-   `ALTER TABLE ... DETACH PARTITION ... CONCURRENTLY`.
+2. Those partitions can be detached with `ALTER TABLE ... DETACH PARTITION ...`.
+   When no DEFAULT partition is attached, `... CONCURRENTLY` can be used.
 3. Detached tables can then be dropped.
 
 Why this is split: `DETACH ... CONCURRENTLY` must run as top-level SQL.
@@ -203,9 +206,13 @@ absurdctl cron --disable --queue jobs
 2. **cleanup** (`absurd.cleanup_all_queues(...)`)
 3. **detach planning** (`absurd.schedule_detach_jobs(...)`)
 
-Detach planning then creates per-partition detach/drop jobs as needed.
+Detach planning creates one active detach/drop pipeline per parent table.
+It schedules only the oldest eligible partition for each parent at a time.
 
-- detach jobs run top-level `DETACH PARTITION ... CONCURRENTLY`
+- detach jobs run top-level `DETACH PARTITION` statements
+  - when possible, they use `CONCURRENTLY`
+  - if a parent still has an attached `DEFAULT` partition, they fall back to
+    non-concurrent detach (Postgres limitation)
 - drop jobs call `absurd.drop_detached_partition(...)` until the table is safe to drop
 - both unschedule themselves when done
 
@@ -226,8 +233,11 @@ For lower-volume queues, keep `unpartitioned` and only configure cleanup.
 ## Notes and Caveats
 
 - Partitioning is currently based on UUIDv7 time ranges and weekly buckets.
-- Default (`_d`) partitions are intentionally kept as a safety net for rows
+- `default_partition=enabled` keeps `_d` partitions as a safety net for rows
   outside pre-created weekly windows.
+- `default_partition=disabled` removes attached `_d` partitions (if empty) and
+  causes out-of-window writes to fail until matching weekly partitions are
+  created.
 - `detach_mode=empty` only detaches partitions that are both old enough and
   empty.
 - `pg_cron` integration requires `cron.job` plus `cron.schedule` and

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,231 @@
+# Storage
+
+Absurd supports two queue storage modes:
+
+- **`unpartitioned`** (default)
+- **`partitioned`** (weekly range partitions)
+
+This page explains when to use each mode, what gets created in Postgres, and
+how to automate partition creation and cleanup with `absurdctl` and `pg_cron`.
+
+## Quick Recommendation
+
+- Start with **unpartitioned** for small/medium workloads or when you want the
+  simplest operations.
+- Use **partitioned** when task history volume is high and you want easier,
+  safer retention operations over time windows.
+
+## What Each Mode Creates
+
+For every queue, Absurd creates queue-local tables in the `absurd` schema:
+
+- `t_<queue>` tasks
+- `r_<queue>` runs
+- `c_<queue>` checkpoints
+- `e_<queue>` evente
+- `w_<queue>` waits
+
+For **partitioned** queues:
+
+- `t_`, `r_`, `c_`, `w_` are declarative partitioned parent tables
+- weekly child partitions are created with a suffix like `<YWW>` (ISO year + ISO week)
+- default catch-all partitions are created with `_d` suffix
+- an additional `i_<queue>` table is created for idempotency-key mapping
+
+Both `i_<queue>` and `e_<queue>` remain unpartitioned.
+
+## Creating Queues
+
+Queues need to be created manually before usage though the SDKs can create them for you
+as well.
+
+### Unpartitioned
+
+```bash
+absurdctl create-queue jobs
+```
+
+Equivalent SQL:
+
+```sql
+select absurd.create_queue('jobs');
+```
+
+### Partitioned
+
+```bash
+absurdctl create-queue jobs --storage-mode partitioned
+```
+
+Equivalent SQL:
+
+```sql
+select absurd.create_queue('jobs', 'partitioned');
+```
+
+`create_queue` is idempotent if the queue already exists with the same storage
+mode.  If you try to recreate with a different mode, Absurd raises an error.
+
+## Queue Storage Policy
+
+Each queue has policy fields in `absurd.queues`:
+
+- `partition_lookahead` (default `28 days`)
+- `partition_lookback` (default `1 day`)
+- `cleanup_ttl` (default `30 days`)
+- `cleanup_limit` (default `1000`)
+- `detach_mode` (`none` or `empty`, default `none`)
+- `detach_min_age` (default `30 days`)
+
+Read/update policy with `absurdctl`:
+
+```bash
+# show
+absurdctl queue-policy jobs
+
+# update
+absurdctl queue-policy jobs \
+  --partition-lookahead '42 days' \
+  --partition-lookback '2 days' \
+  --cleanup-ttl '30 days' \
+  --cleanup-limit 2000 \
+  --detach-mode empty \
+  --detach-min-age '30 days'
+```
+
+Equivalent SQL:
+
+```sql
+select absurd.set_queue_policy(
+  'jobs',
+  '{
+    "partition_lookahead": "42 days",
+    "partition_lookback": "2 days",
+    "cleanup_ttl": "30 days",
+    "cleanup_limit": 2000,
+    "detach_mode": "empty",
+    "detach_min_age": "30 days"
+  }'::jsonb
+);
+```
+
+## Partition Provisioning (Creating Partitions Ahead of Time)
+
+Partitioned queues use `absurd.ensure_partitions(...)`.
+
+For each partitioned queue, it creates partitions over this window:
+
+- `start = week_bucket_utc(now - partition_lookback)`
+- `end   = week_bucket_utc(now + partition_lookahead)`
+
+Run manually:
+
+```sql
+-- one queue
+select absurd.ensure_partitions('jobs');
+
+-- all partitioned queues
+select absurd.ensure_partitions();
+```
+
+This is safe to run repeatedly.
+
+## Cleanup Retention
+
+Cleanup is policy-driven per queue.
+
+Run for all queues at once:
+
+```sql
+select * from absurd.cleanup_all_queues();
+```
+
+You can still run queue-specific cleanup directly:
+
+```sql
+select absurd.cleanup_tasks('jobs', 30 * 86400, 1000);
+select absurd.cleanup_events('jobs', 30 * 86400, 1000);
+```
+
+See also: **[Cleanup and Retention](./cleanup.md)**.
+
+## Detaching Old Empty Partitions
+
+For partitioned queues, Absurd supports policy-based detach planning:
+
+1. `absurd.list_detach_candidates(...)` finds old, empty weekly partitions.
+2. Those partitions can be detached with
+   `ALTER TABLE ... DETACH PARTITION ... CONCURRENTLY`.
+3. Detached tables can then be dropped.
+
+Why this is split: `DETACH ... CONCURRENTLY` must run as top-level SQL.
+
+### Manual flow with `absurdctl`
+
+```bash
+absurdctl list-detach-candidates --queue jobs
+absurdctl detach-candidate --queue jobs <candidate_hash>
+absurdctl detach-candidate --queue jobs <candidate_hash> --drop
+```
+
+## Automating with `pg_cron`
+
+If `pg_cron` is available, Absurd can manage cron jobs for you.
+
+### One command via absurdctl
+
+```bash
+# Global jobs for all queues
+absurdctl cron --enable
+
+# Queue-scoped jobs with custom schedules
+absurdctl cron --enable --queue jobs \
+  --partition-schedule '*/15 * * * *' \
+  --cleanup-schedule '7 * * * *' \
+  --detach-schedule '29 * * * *'
+```
+
+Disable again:
+
+```bash
+absurdctl cron --disable
+absurdctl cron --disable --queue jobs
+```
+
+### What gets scheduled
+
+`absurd.enable_cron(...)` installs three recurring jobs:
+
+1. **partition provisioning** (`absurd.ensure_partitions(...)`)
+2. **cleanup** (`absurd.cleanup_all_queues(...)`)
+3. **detach planning** (`absurd.ensure_detach_jobs(...)`)
+
+Detach planning then creates per-partition detach/drop jobs as needed.
+
+- detach jobs run top-level `DETACH PARTITION ... CONCURRENTLY`
+- drop jobs call `absurd.drop_detached_partition(...)` until the table is safe to drop
+- both unschedule themselves when done
+
+## Practical Operating Model
+
+A common setup for high-throughput queues:
+
+1. Create queue as `partitioned`.
+2. Set policy (`queue-policy`) for lookahead/lookback and retention.
+3. Enable cron (`absurdctl cron --enable --queue ...`).
+4. Periodically inspect:
+   - `absurdctl queue-policy <queue>`
+   - `absurdctl list-detach-candidates --queue <queue>`
+   - `select * from cron.job` (if you want direct DB visibility)
+
+For lower-volume queues, keep `unpartitioned` and only configure cleanup.
+
+## Notes and Caveats
+
+- Partitioning is currently based on UUIDv7 time ranges and weekly buckets.
+- Default (`_d`) partitions are intentionally kept as a safety net for rows
+  outside pre-created weekly windows.
+- `detach_mode=empty` only detaches partitions that are both old enough and
+  empty.
+- `pg_cron` integration requires `cron.job` plus `cron.schedule` and
+  `cron.unschedule` functions to exist.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -29,6 +29,8 @@ For **partitioned** queues:
 
 - `t_`, `r_`, `c_`, `w_` are declarative partitioned parent tables
 - weekly child partitions are created with a suffix like `<YWW>` (ISO year + ISO week)
+  where `Y` is the last ISO year digit, so partition names roll over every 10
+  years
 - default catch-all partitions are created with `_d` suffix
 - an additional `i_<queue>` table is created for idempotency-key mapping
 
@@ -233,6 +235,9 @@ For lower-volume queues, keep `unpartitioned` and only configure cleanup.
 ## Notes and Caveats
 
 - Partitioning is currently based on UUIDv7 time ranges and weekly buckets.
+- Weekly partition names use `<YWW>` where `Y` is one ISO year digit, so names
+  roll over every 10 years; practical retention must stay below that horizon to
+  avoid partition name collisions.
 - `default_partition=enabled` keeps `_d` partitions as a safety net for rows
   outside pre-created weekly windows.
 - `default_partition=disabled` removes attached `_d` partitions (if empty) and

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -198,7 +198,7 @@ absurdctl cron --disable --queue jobs
 
 1. **partition provisioning** (`absurd.ensure_partitions(...)`)
 2. **cleanup** (`absurd.cleanup_all_queues(...)`)
-3. **detach planning** (`absurd.ensure_detach_jobs(...)`)
+3. **detach planning** (`absurd.schedule_detach_jobs(...)`)
 
 Detach planning then creates per-partition detach/drop jobs as needed.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -164,8 +164,8 @@ Why this is split: `DETACH ... CONCURRENTLY` must run as top-level SQL.
 
 ```bash
 absurdctl list-detach-candidates --queue jobs
-absurdctl detach-candidate --queue jobs <candidate_hash>
-absurdctl detach-candidate --queue jobs <candidate_hash> --drop
+absurdctl detach-candidate --queue jobs <partition_table>
+absurdctl detach-candidate --queue jobs <partition_table> --drop
 ```
 
 ## Automating with `pg_cron`

--- a/docs/tools/absurdctl.md
+++ b/docs/tools/absurdctl.md
@@ -166,7 +166,7 @@ View or update per-queue maintenance policy.
 absurdctl queue-policy jobs
 
 # Update cleanup behavior
-absurdctl queue-policy jobs --cleanup-ttl-seconds 604800 --cleanup-limit 2000
+absurdctl queue-policy jobs --cleanup-ttl '7 days' --cleanup-limit 2000
 
 # Update partition window and detach behavior
 absurdctl queue-policy jobs \
@@ -182,7 +182,7 @@ Options:
 |------|-------------|
 | `--partition-lookahead INTERVAL` | Partition lookahead window |
 | `--partition-lookback INTERVAL` | Partition lookback window |
-| `--cleanup-ttl-seconds SECONDS` | Cleanup retention TTL in seconds |
+| `--cleanup-ttl INTERVAL` | Cleanup retention interval |
 | `--cleanup-limit N` | Cleanup batch size |
 | `--detach-mode MODE` | Detach mode: `none` or `empty` |
 | `--detach-min-age INTERVAL` | Minimum partition age before detach planning |

--- a/docs/tools/absurdctl.md
+++ b/docs/tools/absurdctl.md
@@ -340,16 +340,22 @@ absurdctl emit-event --queue=orders shipment.packed -P tracking:='"XYZ"'
 
 ### `cleanup`
 
-Delete old completed, failed, or cancelled tasks and events.  Takes a queue name
-and a TTL in days.
+Delete old completed, failed, or cancelled tasks and events for one queue.
+Takes a queue name and a TTL in days.
 
 ```bash
-absurdctl cleanup default 7     # delete data older than 7 days
-absurdctl cleanup emails 30     # 30-day retention
+absurdctl cleanup default 7
+absurdctl cleanup emails 30
 ```
 
-For batching, direct SQL usage, and cron/job examples, see
-**[Cleanup and Retention](./cleanup.md)**.
+Use this primarily for ad-hoc/manual cleanup.  For regular operations, prefer
+queue policy (`absurdctl queue-policy`) plus cron-managed
+`absurd.cleanup_all_queues(...)`.
+
+See:
+
+- **[Cleanup and Retention](../cleanup.md)** for the policy-driven model
+- **[Storage](../storage.md)** for partition lifecycle + cron maintenance
 
 ## Agent Skills
 

--- a/docs/tools/absurdctl.md
+++ b/docs/tools/absurdctl.md
@@ -253,8 +253,8 @@ absurdctl list-detach-candidates --queue jobs --show-sql
 Execute one candidate's `DETACH PARTITION ... CONCURRENTLY` manually.
 
 ```bash
-absurdctl detach-candidate --queue jobs 1a2b3c4d5e6f
-absurdctl detach-candidate --queue jobs 1a2b3c4d5e6f --drop
+absurdctl detach-candidate --queue jobs t_jobs_2414
+absurdctl detach-candidate --queue jobs t_jobs_2414 --drop
 ```
 
 Use `--drop` to attempt an immediate follow-up drop via

--- a/docs/tools/absurdctl.md
+++ b/docs/tools/absurdctl.md
@@ -148,7 +148,44 @@ Create a new queue.  This creates the per-queue tables (`t_`, `r_`, `c_`, `e_`, 
 ```bash
 absurdctl create-queue default
 absurdctl create-queue emails -d mydb
+absurdctl create-queue jobs --storage-mode partitioned
 ```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--storage-mode` | Queue storage mode: `unpartitioned` (default) or `partitioned` |
+
+### `queue-policy`
+
+View or update per-queue maintenance policy.
+
+```bash
+# Show current policy
+absurdctl queue-policy jobs
+
+# Update cleanup behavior
+absurdctl queue-policy jobs --cleanup-ttl-seconds 604800 --cleanup-limit 2000
+
+# Update partition window and detach behavior
+absurdctl queue-policy jobs \
+  --partition-lookahead '42 days' \
+  --partition-lookback '2 days' \
+  --detach-mode empty \
+  --detach-min-age '30 days'
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--partition-lookahead INTERVAL` | Partition lookahead window |
+| `--partition-lookback INTERVAL` | Partition lookback window |
+| `--cleanup-ttl-seconds SECONDS` | Cleanup retention TTL in seconds |
+| `--cleanup-limit N` | Cleanup batch size |
+| `--detach-mode MODE` | Detach mode: `none` or `empty` |
+| `--detach-min-age INTERVAL` | Minimum partition age before detach planning |
 
 ### `drop-queue`
 
@@ -165,6 +202,63 @@ List all existing queues.
 ```bash
 absurdctl list-queues
 ```
+
+## Cron Maintenance
+
+### `cron`
+
+Enable or disable Absurd-managed `pg_cron` jobs for partition provisioning,
+cleanup, and detach planning.
+
+```bash
+# Enable global/all-queue jobs
+absurdctl cron --enable
+
+# Enable queue-scoped jobs with custom cadence
+absurdctl cron --enable --queue jobs \
+  --partition-schedule '*/15 * * * *' \
+  --cleanup-schedule '7 * * * *' \
+  --detach-schedule '29 * * * *'
+
+# Disable jobs
+absurdctl cron --disable --queue jobs
+absurdctl cron --disable
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--enable` | Enable cron jobs |
+| `--disable` | Disable cron jobs |
+| `--queue NAME` | Optional queue scope (omit for global/all scope) |
+| `--partition-schedule CRON` | Schedule for `ensure_partitions` |
+| `--cleanup-schedule CRON` | Schedule for `cleanup_all_queues` |
+| `--detach-schedule CRON` | Schedule for detach job planning |
+
+## Partition Detach Operations
+
+### `list-detach-candidates`
+
+List eligible partition detach candidates computed from queue policy.
+
+```bash
+absurdctl list-detach-candidates
+absurdctl list-detach-candidates --queue jobs
+absurdctl list-detach-candidates --queue jobs --show-sql
+```
+
+### `detach-candidate`
+
+Execute one candidate's `DETACH PARTITION ... CONCURRENTLY` manually.
+
+```bash
+absurdctl detach-candidate --queue jobs 1a2b3c4d5e6f
+absurdctl detach-candidate --queue jobs 1a2b3c4d5e6f --drop
+```
+
+Use `--drop` to attempt an immediate follow-up drop via
+`absurd.drop_detached_partition(...)`.
 
 ## Task Operations
 

--- a/docs/tools/absurdctl.md
+++ b/docs/tools/absurdctl.md
@@ -168,8 +168,9 @@ absurdctl queue-policy jobs
 # Update cleanup behavior
 absurdctl queue-policy jobs --cleanup-ttl '7 days' --cleanup-limit 2000
 
-# Update partition window and detach behavior
+# Update partition window, default partition, and detach behavior
 absurdctl queue-policy jobs \
+  --default-partition disabled \
   --partition-lookahead '42 days' \
   --partition-lookback '2 days' \
   --detach-mode empty \
@@ -180,6 +181,7 @@ Options:
 
 | Flag | Description |
 |------|-------------|
+| `--default-partition MODE` | Default partition mode: `enabled` or `disabled` (partitioned queues only) |
 | `--partition-lookahead INTERVAL` | Partition lookahead window |
 | `--partition-lookback INTERVAL` | Partition lookback window |
 | `--cleanup-ttl INTERVAL` | Cleanup retention interval |
@@ -250,7 +252,8 @@ absurdctl list-detach-candidates --queue jobs --show-sql
 
 ### `detach-candidate`
 
-Execute one candidate's `DETACH PARTITION ... CONCURRENTLY` manually.
+Execute one candidate's `DETACH PARTITION ...` manually.
+(Uses `CONCURRENTLY` only when the candidate SQL is eligible.)
 
 ```bash
 absurdctl detach-candidate --queue jobs t_jobs_2414

--- a/sdks/go/absurd/absurd.go
+++ b/sdks/go/absurd/absurd.go
@@ -120,7 +120,7 @@ const (
 type QueuePolicyOptions struct {
 	PartitionLookahead string
 	PartitionLookback  string
-	CleanupTTLSeconds  *int
+	CleanupTTL         string
 	CleanupLimit       *int
 	DetachMode         QueueDetachMode
 	DetachMinAge       string
@@ -138,7 +138,7 @@ type QueuePolicy struct {
 	StorageMode        QueueStorageMode
 	PartitionLookahead string
 	PartitionLookback  string
-	CleanupTTLSeconds  int
+	CleanupTTL         string
 	CleanupLimit       int
 	DetachMode         QueueDetachMode
 	DetachMinAge       string
@@ -554,7 +554,7 @@ func (c *Client) GetQueuePolicy(ctx context.Context, queueName string) (*QueuePo
       storage_mode,
       partition_lookahead::text,
       partition_lookback::text,
-      cleanup_ttl_seconds,
+      cleanup_ttl::text,
       cleanup_limit,
       detach_mode,
       detach_min_age::text
@@ -568,7 +568,7 @@ func (c *Client) GetQueuePolicy(ctx context.Context, queueName string) (*QueuePo
 		&storageMode,
 		&policy.PartitionLookahead,
 		&policy.PartitionLookback,
-		&policy.CleanupTTLSeconds,
+		&policy.CleanupTTL,
 		&policy.CleanupLimit,
 		&detachMode,
 		&policy.DetachMinAge,
@@ -931,8 +931,8 @@ func queuePolicyPayload(options QueuePolicyOptions) (map[string]any, error) {
 	if options.PartitionLookback != "" {
 		payload["partition_lookback"] = options.PartitionLookback
 	}
-	if options.CleanupTTLSeconds != nil {
-		payload["cleanup_ttl_seconds"] = *options.CleanupTTLSeconds
+	if options.CleanupTTL != "" {
+		payload["cleanup_ttl"] = options.CleanupTTL
 	}
 	if options.CleanupLimit != nil {
 		payload["cleanup_limit"] = *options.CleanupLimit

--- a/sdks/go/absurd/absurd.go
+++ b/sdks/go/absurd/absurd.go
@@ -423,7 +423,7 @@ func New(options Options) (*Client, error) {
 	if options.DB != nil {
 		db = options.DB
 	} else {
-		driverName := strings.TrimSpace(options.DriverName)
+		driverName := options.DriverName
 		if driverName == "" {
 			driverName = defaultDriverName
 		}
@@ -484,7 +484,7 @@ func (c *Client) MustRegister(task taskRegistration) {
 }
 
 func (c *Client) CreateQueue(ctx context.Context, queueName string, options ...CreateQueueOptions) error {
-	if strings.TrimSpace(queueName) == "" {
+	if queueName == "" {
 		queueName = c.queueName
 	}
 	validated, err := validateQueueName(queueName)
@@ -515,7 +515,7 @@ func (c *Client) CreateQueue(ctx context.Context, queueName string, options ...C
 }
 
 func (c *Client) SetQueuePolicy(ctx context.Context, queueName string, options QueuePolicyOptions) error {
-	if strings.TrimSpace(queueName) == "" {
+	if queueName == "" {
 		queueName = c.queueName
 	}
 	validated, err := validateQueueName(queueName)
@@ -541,7 +541,7 @@ func (c *Client) SetQueuePolicy(ctx context.Context, queueName string, options Q
 }
 
 func (c *Client) GetQueuePolicy(ctx context.Context, queueName string) (*QueuePolicy, error) {
-	if strings.TrimSpace(queueName) == "" {
+	if queueName == "" {
 		queueName = c.queueName
 	}
 	validated, err := validateQueueName(queueName)
@@ -856,7 +856,7 @@ func failTaskRunWithTraceback(ctx context.Context, db *sql.DB, queueName string,
 // Utility functions
 
 func validateQueueName(queueName string) (string, error) {
-	if strings.TrimSpace(queueName) == "" {
+	if queueName == "" {
 		return "", fmt.Errorf("queue name must be provided")
 	}
 	if len([]byte(queueName)) > maxQueueNameLength {

--- a/sdks/go/absurd/absurd.go
+++ b/sdks/go/absurd/absurd.go
@@ -938,9 +938,6 @@ func queuePolicyPayload(options QueuePolicyOptions) (map[string]any, error) {
 		payload["cleanup_limit"] = *options.CleanupLimit
 	}
 	if options.DetachMode != "" {
-		if options.DetachMode != QueueDetachNone && options.DetachMode != QueueDetachEmpty {
-			return nil, fmt.Errorf("invalid detach mode: %s", options.DetachMode)
-		}
 		payload["detach_mode"] = string(options.DetachMode)
 	}
 	if options.DetachMinAge != "" {

--- a/sdks/go/absurd/absurd.go
+++ b/sdks/go/absurd/absurd.go
@@ -102,6 +102,48 @@ type SpawnOptions struct {
 	IdempotencyKey string
 }
 
+type QueueStorageMode string
+
+const (
+	QueueStorageUnpartitioned QueueStorageMode = "unpartitioned"
+	QueueStoragePartitioned   QueueStorageMode = "partitioned"
+)
+
+type QueueDetachMode string
+
+const (
+	QueueDetachNone  QueueDetachMode = "none"
+	QueueDetachEmpty QueueDetachMode = "empty"
+)
+
+// QueuePolicyOptions configure queue maintenance policy updates.
+type QueuePolicyOptions struct {
+	PartitionLookahead string
+	PartitionLookback  string
+	CleanupTTLSeconds  *int
+	CleanupLimit       *int
+	DetachMode         QueueDetachMode
+	DetachMinAge       string
+}
+
+// CreateQueueOptions configure queue creation mode and policy.
+type CreateQueueOptions struct {
+	StorageMode QueueStorageMode
+	QueuePolicyOptions
+}
+
+// QueuePolicy is the persisted maintenance policy metadata for a queue.
+type QueuePolicy struct {
+	QueueName          string
+	StorageMode        QueueStorageMode
+	PartitionLookahead string
+	PartitionLookback  string
+	CleanupTTLSeconds  int
+	CleanupLimit       int
+	DetachMode         QueueDetachMode
+	DetachMinAge       string
+}
+
 // RetryTaskOptions configure retrying a failed task.
 type RetryTaskOptions struct {
 	MaxAttempts int
@@ -441,13 +483,105 @@ func (c *Client) MustRegister(task taskRegistration) {
 	}
 }
 
-func (c *Client) CreateQueue(ctx context.Context, queueName string) error {
+func (c *Client) CreateQueue(ctx context.Context, queueName string, options ...CreateQueueOptions) error {
+	if strings.TrimSpace(queueName) == "" {
+		queueName = c.queueName
+	}
 	validated, err := validateQueueName(queueName)
 	if err != nil {
 		return err
 	}
-	_, err = c.db.ExecContext(ctx, `SELECT absurd.create_queue($1)`, validated)
+
+	opts := first(options)
+	storageMode := string(opts.StorageMode)
+	if storageMode == "" {
+		storageMode = string(QueueStorageUnpartitioned)
+	}
+	if storageMode != string(QueueStorageUnpartitioned) && storageMode != string(QueueStoragePartitioned) {
+		return fmt.Errorf("invalid queue storage mode: %s", storageMode)
+	}
+
+	if storageMode == string(QueueStorageUnpartitioned) {
+		if _, err := c.db.ExecContext(ctx, `SELECT absurd.create_queue($1)`, validated); err != nil {
+			return err
+		}
+	} else {
+		if _, err := c.db.ExecContext(ctx, `SELECT absurd.create_queue($1, $2)`, validated, storageMode); err != nil {
+			return err
+		}
+	}
+
+	return c.SetQueuePolicy(ctx, validated, opts.QueuePolicyOptions)
+}
+
+func (c *Client) SetQueuePolicy(ctx context.Context, queueName string, options QueuePolicyOptions) error {
+	if strings.TrimSpace(queueName) == "" {
+		queueName = c.queueName
+	}
+	validated, err := validateQueueName(queueName)
+	if err != nil {
+		return err
+	}
+
+	payload, err := queuePolicyPayload(options)
+	if err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+
+	raw, err := marshalJSON(payload)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.db.ExecContext(ctx, `SELECT absurd.set_queue_policy($1, $2::jsonb)`, validated, string(raw))
 	return err
+}
+
+func (c *Client) GetQueuePolicy(ctx context.Context, queueName string) (*QueuePolicy, error) {
+	if strings.TrimSpace(queueName) == "" {
+		queueName = c.queueName
+	}
+	validated, err := validateQueueName(queueName)
+	if err != nil {
+		return nil, err
+	}
+
+	row := c.db.QueryRowContext(ctx, `SELECT
+      queue_name,
+      storage_mode,
+      partition_lookahead::text,
+      partition_lookback::text,
+      cleanup_ttl_seconds,
+      cleanup_limit,
+      detach_mode,
+      detach_min_age::text
+    FROM absurd.get_queue_policy($1)`, validated)
+
+	var policy QueuePolicy
+	var storageMode string
+	var detachMode string
+	if err := row.Scan(
+		&policy.QueueName,
+		&storageMode,
+		&policy.PartitionLookahead,
+		&policy.PartitionLookback,
+		&policy.CleanupTTLSeconds,
+		&policy.CleanupLimit,
+		&detachMode,
+		&policy.DetachMinAge,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	policy.StorageMode = QueueStorageMode(storageMode)
+	policy.DetachMode = QueueDetachMode(detachMode)
+	return &policy, nil
 }
 
 func (c *Client) DropQueue(ctx context.Context, queueName string) error {
@@ -787,6 +921,32 @@ func first[T any](values []T) T {
 	default:
 		panic(fmt.Sprintf("absurd: expected 0 or 1 optional arguments, got %d", len(values)))
 	}
+}
+
+func queuePolicyPayload(options QueuePolicyOptions) (map[string]any, error) {
+	payload := map[string]any{}
+	if options.PartitionLookahead != "" {
+		payload["partition_lookahead"] = options.PartitionLookahead
+	}
+	if options.PartitionLookback != "" {
+		payload["partition_lookback"] = options.PartitionLookback
+	}
+	if options.CleanupTTLSeconds != nil {
+		payload["cleanup_ttl_seconds"] = *options.CleanupTTLSeconds
+	}
+	if options.CleanupLimit != nil {
+		payload["cleanup_limit"] = *options.CleanupLimit
+	}
+	if options.DetachMode != "" {
+		if options.DetachMode != QueueDetachNone && options.DetachMode != QueueDetachEmpty {
+			return nil, fmt.Errorf("invalid detach mode: %s", options.DetachMode)
+		}
+		payload["detach_mode"] = string(options.DetachMode)
+	}
+	if options.DetachMinAge != "" {
+		payload["detach_min_age"] = options.DetachMinAge
+	}
+	return payload, nil
 }
 
 func orString(value, fallback string) string {

--- a/sdks/go/tests/parity_test.go
+++ b/sdks/go/tests/parity_test.go
@@ -696,12 +696,6 @@ func TestFailureIncludesTraceback(t *testing.T) {
 	}
 }
 
-func TestQueueNameRejectsWhitespaceOnly(t *testing.T) {
-	_, err := absurd.New(absurd.Options{DB: setupTestDatabase(t), QueueName: "   "})
-	if err == nil || !strings.Contains(err.Error(), "queue name must be provided") {
-		t.Fatalf("expected queue validation error, got %v", err)
-	}
-}
 
 func TestInvalidHeadersFailRun(t *testing.T) {
 	queue := randomQueueName("go_invalid_headers")

--- a/sdks/go/tests/parity_test.go
+++ b/sdks/go/tests/parity_test.go
@@ -88,6 +88,71 @@ func TestListQueues(t *testing.T) {
 	}
 }
 
+func TestQueuePolicyMethods(t *testing.T) {
+	queue := randomQueueName("go_queue_policy")
+	db := setupTestDatabase(t)
+	client, err := absurd.New(absurd.Options{DB: db, QueueName: queue})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ttl := 12345
+	limit := 77
+	if err := client.CreateQueue(context.Background(), queue, absurd.CreateQueueOptions{
+		StorageMode: absurd.QueueStoragePartitioned,
+		QueuePolicyOptions: absurd.QueuePolicyOptions{
+			PartitionLookahead: "35 days",
+			PartitionLookback:  "2 days",
+			CleanupTTLSeconds:  &ttl,
+			CleanupLimit:       &limit,
+			DetachMode:         absurd.QueueDetachEmpty,
+			DetachMinAge:       "45 days",
+		},
+	}); err != nil {
+		t.Fatalf("CreateQueue with options: %v", err)
+	}
+
+	policy, err := client.GetQueuePolicy(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("GetQueuePolicy: %v", err)
+	}
+	if policy == nil {
+		t.Fatal("expected queue policy")
+	}
+	if policy.StorageMode != absurd.QueueStoragePartitioned {
+		t.Fatalf("unexpected storage mode: %s", policy.StorageMode)
+	}
+	if policy.PartitionLookahead != "35 days" || policy.PartitionLookback != "2 days" {
+		t.Fatalf("unexpected partition window: %#v", policy)
+	}
+	if policy.CleanupTTLSeconds != 12345 || policy.CleanupLimit != 77 {
+		t.Fatalf("unexpected cleanup policy: %#v", policy)
+	}
+	if policy.DetachMode != absurd.QueueDetachEmpty || policy.DetachMinAge != "45 days" {
+		t.Fatalf("unexpected detach policy: %#v", policy)
+	}
+
+	updatedTTL := 4321
+	updatedLimit := 12
+	if err := client.SetQueuePolicy(context.Background(), queue, absurd.QueuePolicyOptions{
+		CleanupTTLSeconds: &updatedTTL,
+		CleanupLimit:      &updatedLimit,
+	}); err != nil {
+		t.Fatalf("SetQueuePolicy: %v", err)
+	}
+
+	updated, err := client.GetQueuePolicy(context.Background(), queue)
+	if err != nil {
+		t.Fatalf("GetQueuePolicy updated: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("expected updated queue policy")
+	}
+	if updated.CleanupTTLSeconds != updatedTTL || updated.CleanupLimit != updatedLimit {
+		t.Fatalf("unexpected updated cleanup policy: %#v", updated)
+	}
+}
+
 func TestSpawnOptionsParity(t *testing.T) {
 	queue := randomQueueName("go_spawn_opts")
 	client := newTestClient(t, queue)

--- a/sdks/go/tests/parity_test.go
+++ b/sdks/go/tests/parity_test.go
@@ -96,14 +96,14 @@ func TestQueuePolicyMethods(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	ttl := 12345
+	ttl := "12345 seconds"
 	limit := 77
 	if err := client.CreateQueue(context.Background(), queue, absurd.CreateQueueOptions{
 		StorageMode: absurd.QueueStoragePartitioned,
 		QueuePolicyOptions: absurd.QueuePolicyOptions{
 			PartitionLookahead: "35 days",
 			PartitionLookback:  "2 days",
-			CleanupTTLSeconds:  &ttl,
+			CleanupTTL:         ttl,
 			CleanupLimit:       &limit,
 			DetachMode:         absurd.QueueDetachEmpty,
 			DetachMinAge:       "45 days",
@@ -125,18 +125,20 @@ func TestQueuePolicyMethods(t *testing.T) {
 	if policy.PartitionLookahead != "35 days" || policy.PartitionLookback != "2 days" {
 		t.Fatalf("unexpected partition window: %#v", policy)
 	}
-	if policy.CleanupTTLSeconds != 12345 || policy.CleanupLimit != 77 {
+	if policy.CleanupTTL != "3:25:45" && policy.CleanupTTL != "03:25:45" {
+		t.Fatalf("unexpected cleanup ttl: %#v", policy)
+	}
+	if policy.CleanupLimit != 77 {
 		t.Fatalf("unexpected cleanup policy: %#v", policy)
 	}
 	if policy.DetachMode != absurd.QueueDetachEmpty || policy.DetachMinAge != "45 days" {
 		t.Fatalf("unexpected detach policy: %#v", policy)
 	}
 
-	updatedTTL := 4321
 	updatedLimit := 12
 	if err := client.SetQueuePolicy(context.Background(), queue, absurd.QueuePolicyOptions{
-		CleanupTTLSeconds: &updatedTTL,
-		CleanupLimit:      &updatedLimit,
+		CleanupTTL:   "4321 seconds",
+		CleanupLimit: &updatedLimit,
 	}); err != nil {
 		t.Fatalf("SetQueuePolicy: %v", err)
 	}
@@ -148,7 +150,10 @@ func TestQueuePolicyMethods(t *testing.T) {
 	if updated == nil {
 		t.Fatal("expected updated queue policy")
 	}
-	if updated.CleanupTTLSeconds != updatedTTL || updated.CleanupLimit != updatedLimit {
+	if updated.CleanupTTL != "1:12:01" && updated.CleanupTTL != "01:12:01" {
+		t.Fatalf("unexpected updated cleanup ttl: %#v", updated)
+	}
+	if updated.CleanupLimit != updatedLimit {
 		t.Fatalf("unexpected updated cleanup policy: %#v", updated)
 	}
 }

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -118,7 +118,7 @@ class QueuePolicyOptions(TypedDict, total=False):
 
     partition_lookahead: str
     partition_lookback: str
-    cleanup_ttl_seconds: int
+    cleanup_ttl: str
     cleanup_limit: int
     detach_mode: QueueDetachMode
     detach_min_age: str
@@ -137,7 +137,7 @@ class QueuePolicy(TypedDict):
     storage_mode: QueueStorageMode
     partition_lookahead: timedelta
     partition_lookback: timedelta
-    cleanup_ttl_seconds: int
+    cleanup_ttl: timedelta
     cleanup_limit: int
     detach_mode: QueueDetachMode
     detach_min_age: timedelta
@@ -540,7 +540,7 @@ def _normalize_spawn_options(
 def _normalize_queue_policy_options(
     partition_lookahead: Optional[str] = None,
     partition_lookback: Optional[str] = None,
-    cleanup_ttl_seconds: Optional[int] = None,
+    cleanup_ttl: Optional[str] = None,
     cleanup_limit: Optional[int] = None,
     detach_mode: Optional[QueueDetachMode] = None,
     detach_min_age: Optional[str] = None,
@@ -551,8 +551,8 @@ def _normalize_queue_policy_options(
         normalized["partition_lookahead"] = partition_lookahead
     if partition_lookback is not None:
         normalized["partition_lookback"] = partition_lookback
-    if cleanup_ttl_seconds is not None:
-        normalized["cleanup_ttl_seconds"] = cleanup_ttl_seconds
+    if cleanup_ttl is not None:
+        normalized["cleanup_ttl"] = cleanup_ttl
     if cleanup_limit is not None:
         normalized["cleanup_limit"] = cleanup_limit
     if detach_mode is not None:
@@ -1327,7 +1327,7 @@ class Absurd(_AbsurdBase):
         storage_mode: QueueStorageMode = "unpartitioned",
         partition_lookahead: Optional[str] = None,
         partition_lookback: Optional[str] = None,
-        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_ttl: Optional[str] = None,
         cleanup_limit: Optional[int] = None,
         detach_mode: Optional[QueueDetachMode] = None,
         detach_min_age: Optional[str] = None,
@@ -1350,7 +1350,7 @@ class Absurd(_AbsurdBase):
             queue_name=queue,
             partition_lookahead=partition_lookahead,
             partition_lookback=partition_lookback,
-            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_ttl=cleanup_ttl,
             cleanup_limit=cleanup_limit,
             detach_mode=detach_mode,
             detach_min_age=detach_min_age,
@@ -1362,7 +1362,7 @@ class Absurd(_AbsurdBase):
         *,
         partition_lookahead: Optional[str] = None,
         partition_lookback: Optional[str] = None,
-        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_ttl: Optional[str] = None,
         cleanup_limit: Optional[int] = None,
         detach_mode: Optional[QueueDetachMode] = None,
         detach_min_age: Optional[str] = None,
@@ -1375,7 +1375,7 @@ class Absurd(_AbsurdBase):
         policy = _normalize_queue_policy_options(
             partition_lookahead=partition_lookahead,
             partition_lookback=partition_lookback,
-            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_ttl=cleanup_ttl,
             cleanup_limit=cleanup_limit,
             detach_mode=detach_mode,
             detach_min_age=detach_min_age,
@@ -1403,7 +1403,7 @@ class Absurd(_AbsurdBase):
               storage_mode,
               partition_lookahead,
               partition_lookback,
-              cleanup_ttl_seconds,
+              cleanup_ttl,
               cleanup_limit,
               detach_mode,
               detach_min_age
@@ -1727,7 +1727,7 @@ class AsyncAbsurd(_AbsurdBase):
         storage_mode: QueueStorageMode = "unpartitioned",
         partition_lookahead: Optional[str] = None,
         partition_lookback: Optional[str] = None,
-        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_ttl: Optional[str] = None,
         cleanup_limit: Optional[int] = None,
         detach_mode: Optional[QueueDetachMode] = None,
         detach_min_age: Optional[str] = None,
@@ -1752,7 +1752,7 @@ class AsyncAbsurd(_AbsurdBase):
             queue_name=queue,
             partition_lookahead=partition_lookahead,
             partition_lookback=partition_lookback,
-            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_ttl=cleanup_ttl,
             cleanup_limit=cleanup_limit,
             detach_mode=detach_mode,
             detach_min_age=detach_min_age,
@@ -1764,7 +1764,7 @@ class AsyncAbsurd(_AbsurdBase):
         *,
         partition_lookahead: Optional[str] = None,
         partition_lookback: Optional[str] = None,
-        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_ttl: Optional[str] = None,
         cleanup_limit: Optional[int] = None,
         detach_mode: Optional[QueueDetachMode] = None,
         detach_min_age: Optional[str] = None,
@@ -1779,7 +1779,7 @@ class AsyncAbsurd(_AbsurdBase):
         policy = _normalize_queue_policy_options(
             partition_lookahead=partition_lookahead,
             partition_lookback=partition_lookback,
-            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_ttl=cleanup_ttl,
             cleanup_limit=cleanup_limit,
             detach_mode=detach_mode,
             detach_min_age=detach_min_age,
@@ -1809,7 +1809,7 @@ class AsyncAbsurd(_AbsurdBase):
               storage_mode,
               partition_lookahead,
               partition_lookback,
-              cleanup_ttl_seconds,
+              cleanup_ttl,
               cleanup_limit,
               detach_mode,
               detach_min_age

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -285,7 +285,7 @@ _CHECKPOINT_NOT_FOUND = object()
 
 
 def _validate_queue_name(queue_name: str) -> str:
-    if queue_name is None or len(queue_name.strip()) == 0:
+    if queue_name is None or queue_name == "":
         raise ValueError("Queue name must be provided")
 
     if len(queue_name.encode("utf-8")) > _MAX_QUEUE_NAME_LENGTH:

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -45,6 +45,9 @@ __all__ = [
     "RetryStrategy",
     "CancellationPolicy",
     "SpawnOptions",
+    "CreateQueueOptions",
+    "QueuePolicyOptions",
+    "QueuePolicy",
     "RetryTaskResult",
     "TaskResultState",
     "TaskResultSnapshot",
@@ -104,6 +107,40 @@ class SpawnOptions(TypedDict, total=False):
     queue: str
     cancellation: CancellationPolicy
     idempotency_key: str
+
+
+QueueStorageMode = Literal["unpartitioned", "partitioned"]
+QueueDetachMode = Literal["none", "empty"]
+
+
+class QueuePolicyOptions(TypedDict, total=False):
+    """Queue maintenance policy update payload."""
+
+    partition_lookahead: str
+    partition_lookback: str
+    cleanup_ttl_seconds: int
+    cleanup_limit: int
+    detach_mode: QueueDetachMode
+    detach_min_age: str
+
+
+class CreateQueueOptions(QueuePolicyOptions, total=False):
+    """Options used when creating a queue."""
+
+    storage_mode: QueueStorageMode
+
+
+class QueuePolicy(TypedDict):
+    """Queue maintenance policy as returned by the database."""
+
+    queue_name: str
+    storage_mode: QueueStorageMode
+    partition_lookahead: timedelta
+    partition_lookback: timedelta
+    cleanup_ttl_seconds: int
+    cleanup_limit: int
+    detach_mode: QueueDetachMode
+    detach_min_age: timedelta
 
 
 class ClaimedTask(TypedDict):
@@ -496,6 +533,34 @@ def _normalize_spawn_options(
 
     if idempotency_key is not None:
         normalized["idempotency_key"] = idempotency_key
+
+    return normalized
+
+
+def _normalize_queue_policy_options(
+    partition_lookahead: Optional[str] = None,
+    partition_lookback: Optional[str] = None,
+    cleanup_ttl_seconds: Optional[int] = None,
+    cleanup_limit: Optional[int] = None,
+    detach_mode: Optional[QueueDetachMode] = None,
+    detach_min_age: Optional[str] = None,
+) -> JsonObject:
+    normalized: JsonObject = {}
+
+    if partition_lookahead is not None:
+        normalized["partition_lookahead"] = partition_lookahead
+    if partition_lookback is not None:
+        normalized["partition_lookback"] = partition_lookback
+    if cleanup_ttl_seconds is not None:
+        normalized["cleanup_ttl_seconds"] = cleanup_ttl_seconds
+    if cleanup_limit is not None:
+        normalized["cleanup_limit"] = cleanup_limit
+    if detach_mode is not None:
+        if detach_mode not in ("none", "empty"):
+            raise ValueError("detach_mode must be 'none' or 'empty'")
+        normalized["detach_mode"] = detach_mode
+    if detach_min_age is not None:
+        normalized["detach_min_age"] = detach_min_age
 
     return normalized
 
@@ -1255,13 +1320,101 @@ class Absurd(_AbsurdBase):
             self._owned_conn = False
         super().__init__(validated_queue_name, default_max_attempts, hooks)
 
-    def create_queue(self, queue_name: Optional[str] = None) -> None:
-        """Create a queue (defaults to this client's queue)"""
+    def create_queue(
+        self,
+        queue_name: Optional[str] = None,
+        *,
+        storage_mode: QueueStorageMode = "unpartitioned",
+        partition_lookahead: Optional[str] = None,
+        partition_lookback: Optional[str] = None,
+        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_limit: Optional[int] = None,
+        detach_mode: Optional[QueueDetachMode] = None,
+        detach_min_age: Optional[str] = None,
+    ) -> None:
+        """Create a queue (defaults to this client's queue)."""
         queue = _validate_queue_name(
             queue_name if queue_name is not None else self._queue_name
         )
+
+        if storage_mode not in ("unpartitioned", "partitioned"):
+            raise ValueError("storage_mode must be 'unpartitioned' or 'partitioned'")
+
         cursor = self._conn.cursor()
-        cursor.execute("SELECT absurd.create_queue(%s)", (queue,))
+        if storage_mode == "unpartitioned":
+            cursor.execute("SELECT absurd.create_queue(%s)", (queue,))
+        else:
+            cursor.execute("SELECT absurd.create_queue(%s, %s)", (queue, storage_mode))
+
+        self.set_queue_policy(
+            queue_name=queue,
+            partition_lookahead=partition_lookahead,
+            partition_lookback=partition_lookback,
+            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_limit=cleanup_limit,
+            detach_mode=detach_mode,
+            detach_min_age=detach_min_age,
+        )
+
+    def set_queue_policy(
+        self,
+        queue_name: Optional[str] = None,
+        *,
+        partition_lookahead: Optional[str] = None,
+        partition_lookback: Optional[str] = None,
+        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_limit: Optional[int] = None,
+        detach_mode: Optional[QueueDetachMode] = None,
+        detach_min_age: Optional[str] = None,
+    ) -> None:
+        """Update queue maintenance policy fields."""
+        queue = _validate_queue_name(
+            queue_name if queue_name is not None else self._queue_name
+        )
+
+        policy = _normalize_queue_policy_options(
+            partition_lookahead=partition_lookahead,
+            partition_lookback=partition_lookback,
+            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_limit=cleanup_limit,
+            detach_mode=detach_mode,
+            detach_min_age=detach_min_age,
+        )
+
+        if not policy:
+            return
+
+        cursor = self._conn.cursor()
+        cursor.execute(
+            "SELECT absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, json.dumps(policy)),
+        )
+
+    def get_queue_policy(self, queue_name: Optional[str] = None) -> Optional[QueuePolicy]:
+        """Fetch queue maintenance policy fields."""
+        queue = _validate_queue_name(
+            queue_name if queue_name is not None else self._queue_name
+        )
+        cursor = self._conn.cursor(row_factory=dict_row)
+        cursor.execute(
+            """
+            SELECT
+              queue_name,
+              storage_mode,
+              partition_lookahead,
+              partition_lookback,
+              cleanup_ttl_seconds,
+              cleanup_limit,
+              detach_mode,
+              detach_min_age
+            FROM absurd.get_queue_policy(%s)
+            """,
+            (queue,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return cast(QueuePolicy, row)
 
     def drop_queue(self, queue_name: Optional[str] = None) -> None:
         """Drop a queue (defaults to this client's queue)"""
@@ -1567,15 +1720,107 @@ class AsyncAbsurd(_AbsurdBase):
         if self._conn is None and self._conn_string:
             self._conn = await AsyncConnection.connect(self._conn_string, autocommit=True)
 
-    async def create_queue(self, queue_name: Optional[str] = None) -> None:
-        """Create a queue (defaults to this client's queue)"""
+    async def create_queue(
+        self,
+        queue_name: Optional[str] = None,
+        *,
+        storage_mode: QueueStorageMode = "unpartitioned",
+        partition_lookahead: Optional[str] = None,
+        partition_lookback: Optional[str] = None,
+        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_limit: Optional[int] = None,
+        detach_mode: Optional[QueueDetachMode] = None,
+        detach_min_age: Optional[str] = None,
+    ) -> None:
+        """Create a queue (defaults to this client's queue)."""
         await self._ensure_connected()
         assert self._conn is not None
         queue = _validate_queue_name(
             queue_name if queue_name is not None else self._queue_name
         )
+
+        if storage_mode not in ("unpartitioned", "partitioned"):
+            raise ValueError("storage_mode must be 'unpartitioned' or 'partitioned'")
+
         cursor = self._conn.cursor()
-        await cursor.execute("SELECT absurd.create_queue(%s)", (queue,))
+        if storage_mode == "unpartitioned":
+            await cursor.execute("SELECT absurd.create_queue(%s)", (queue,))
+        else:
+            await cursor.execute("SELECT absurd.create_queue(%s, %s)", (queue, storage_mode))
+
+        await self.set_queue_policy(
+            queue_name=queue,
+            partition_lookahead=partition_lookahead,
+            partition_lookback=partition_lookback,
+            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_limit=cleanup_limit,
+            detach_mode=detach_mode,
+            detach_min_age=detach_min_age,
+        )
+
+    async def set_queue_policy(
+        self,
+        queue_name: Optional[str] = None,
+        *,
+        partition_lookahead: Optional[str] = None,
+        partition_lookback: Optional[str] = None,
+        cleanup_ttl_seconds: Optional[int] = None,
+        cleanup_limit: Optional[int] = None,
+        detach_mode: Optional[QueueDetachMode] = None,
+        detach_min_age: Optional[str] = None,
+    ) -> None:
+        """Update queue maintenance policy fields."""
+        await self._ensure_connected()
+        assert self._conn is not None
+        queue = _validate_queue_name(
+            queue_name if queue_name is not None else self._queue_name
+        )
+
+        policy = _normalize_queue_policy_options(
+            partition_lookahead=partition_lookahead,
+            partition_lookback=partition_lookback,
+            cleanup_ttl_seconds=cleanup_ttl_seconds,
+            cleanup_limit=cleanup_limit,
+            detach_mode=detach_mode,
+            detach_min_age=detach_min_age,
+        )
+
+        if not policy:
+            return
+
+        cursor = self._conn.cursor()
+        await cursor.execute(
+            "SELECT absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, json.dumps(policy)),
+        )
+
+    async def get_queue_policy(self, queue_name: Optional[str] = None) -> Optional[QueuePolicy]:
+        """Fetch queue maintenance policy fields."""
+        await self._ensure_connected()
+        assert self._conn is not None
+        queue = _validate_queue_name(
+            queue_name if queue_name is not None else self._queue_name
+        )
+        cursor = self._conn.cursor(row_factory=dict_row)
+        await cursor.execute(
+            """
+            SELECT
+              queue_name,
+              storage_mode,
+              partition_lookahead,
+              partition_lookback,
+              cleanup_ttl_seconds,
+              cleanup_limit,
+              detach_mode,
+              detach_min_age
+            FROM absurd.get_queue_policy(%s)
+            """,
+            (queue,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return cast(QueuePolicy, row)
 
     async def drop_queue(self, queue_name: Optional[str] = None) -> None:
         """Drop a queue (defaults to this client's queue)"""

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -556,8 +556,6 @@ def _normalize_queue_policy_options(
     if cleanup_limit is not None:
         normalized["cleanup_limit"] = cleanup_limit
     if detach_mode is not None:
-        if detach_mode not in ("none", "empty"):
-            raise ValueError("detach_mode must be 'none' or 'empty'")
         normalized["detach_mode"] = detach_mode
     if detach_min_age is not None:
         normalized["detach_min_age"] = detach_min_age

--- a/sdks/python/tests/test_queue_policy.py
+++ b/sdks/python/tests/test_queue_policy.py
@@ -1,0 +1,66 @@
+import asyncio
+
+from absurd_sdk import Absurd, AsyncAbsurd
+
+
+def test_sync_queue_policy_methods(conn, queue_name):
+    queue = queue_name("py_policy")
+    client = Absurd(conn, queue_name="default")
+
+    client.create_queue(
+        queue,
+        storage_mode="partitioned",
+        partition_lookahead="35 days",
+        partition_lookback="2 days",
+        cleanup_ttl_seconds=12345,
+        cleanup_limit=77,
+        detach_mode="empty",
+        detach_min_age="45 days",
+    )
+
+    policy = client.get_queue_policy(queue)
+    assert policy is not None
+    assert policy["queue_name"] == queue
+    assert policy["storage_mode"] == "partitioned"
+    assert str(policy["partition_lookahead"]) == "35 days, 0:00:00"
+    assert str(policy["partition_lookback"]) == "2 days, 0:00:00"
+    assert policy["cleanup_ttl_seconds"] == 12345
+    assert policy["cleanup_limit"] == 77
+    assert policy["detach_mode"] == "empty"
+    assert str(policy["detach_min_age"]) == "45 days, 0:00:00"
+
+    client.set_queue_policy(queue, cleanup_ttl_seconds=4321, cleanup_limit=12)
+
+    updated = client.get_queue_policy(queue)
+    assert updated is not None
+    assert updated["cleanup_ttl_seconds"] == 4321
+    assert updated["cleanup_limit"] == 12
+
+
+def test_async_queue_policy_methods(db_dsn, queue_name):
+    queue = queue_name("apy_policy")
+
+    async def run():
+        client = AsyncAbsurd(db_dsn, queue_name="default")
+        await client.create_queue(
+            queue,
+            storage_mode="partitioned",
+            partition_lookahead="21 days",
+            cleanup_ttl_seconds=999,
+        )
+
+        policy = await client.get_queue_policy(queue)
+        assert policy is not None
+        assert policy["storage_mode"] == "partitioned"
+        assert str(policy["partition_lookahead"]) == "21 days, 0:00:00"
+        assert policy["cleanup_ttl_seconds"] == 999
+
+        await client.set_queue_policy(queue, detach_mode="empty", detach_min_age="10 days")
+        updated = await client.get_queue_policy(queue)
+        assert updated is not None
+        assert updated["detach_mode"] == "empty"
+        assert str(updated["detach_min_age"]) == "10 days, 0:00:00"
+
+        await client.close()
+
+    asyncio.run(run())

--- a/sdks/python/tests/test_queue_policy.py
+++ b/sdks/python/tests/test_queue_policy.py
@@ -12,7 +12,7 @@ def test_sync_queue_policy_methods(conn, queue_name):
         storage_mode="partitioned",
         partition_lookahead="35 days",
         partition_lookback="2 days",
-        cleanup_ttl_seconds=12345,
+        cleanup_ttl="12345 seconds",
         cleanup_limit=77,
         detach_mode="empty",
         detach_min_age="45 days",
@@ -24,16 +24,16 @@ def test_sync_queue_policy_methods(conn, queue_name):
     assert policy["storage_mode"] == "partitioned"
     assert str(policy["partition_lookahead"]) == "35 days, 0:00:00"
     assert str(policy["partition_lookback"]) == "2 days, 0:00:00"
-    assert policy["cleanup_ttl_seconds"] == 12345
+    assert str(policy["cleanup_ttl"]) == "3:25:45"
     assert policy["cleanup_limit"] == 77
     assert policy["detach_mode"] == "empty"
     assert str(policy["detach_min_age"]) == "45 days, 0:00:00"
 
-    client.set_queue_policy(queue, cleanup_ttl_seconds=4321, cleanup_limit=12)
+    client.set_queue_policy(queue, cleanup_ttl="4321 seconds", cleanup_limit=12)
 
     updated = client.get_queue_policy(queue)
     assert updated is not None
-    assert updated["cleanup_ttl_seconds"] == 4321
+    assert str(updated["cleanup_ttl"]) == "1:12:01"
     assert updated["cleanup_limit"] == 12
 
 
@@ -46,14 +46,14 @@ def test_async_queue_policy_methods(db_dsn, queue_name):
             queue,
             storage_mode="partitioned",
             partition_lookahead="21 days",
-            cleanup_ttl_seconds=999,
+            cleanup_ttl="999 seconds",
         )
 
         policy = await client.get_queue_policy(queue)
         assert policy is not None
         assert policy["storage_mode"] == "partitioned"
         assert str(policy["partition_lookahead"]) == "21 days, 0:00:00"
-        assert policy["cleanup_ttl_seconds"] == 999
+        assert str(policy["cleanup_ttl"]) == "0:16:39"
 
         await client.set_queue_policy(queue, detach_mode="empty", detach_min_age="10 days")
         updated = await client.get_queue_policy(queue)

--- a/sdks/python/tests/test_queue_validation.py
+++ b/sdks/python/tests/test_queue_validation.py
@@ -6,7 +6,7 @@ import absurd_sdk
 from absurd_sdk import Absurd, AsyncAbsurd
 
 
-def test_sync_constructor_fails_before_connect_on_invalid_queue(monkeypatch):
+def test_sync_constructor_fails_before_connect_on_empty_queue(monkeypatch):
     called = False
 
     def fake_connect(*args, **kwargs):
@@ -17,7 +17,7 @@ def test_sync_constructor_fails_before_connect_on_invalid_queue(monkeypatch):
     monkeypatch.setattr(absurd_sdk.Connection, "connect", fake_connect)
 
     with pytest.raises(ValueError, match="Queue name must be provided"):
-        Absurd(None, queue_name="   ")
+        Absurd(None, queue_name="")
 
     assert called is False
 
@@ -30,8 +30,10 @@ def test_sync_queue_validation_is_permissive_but_bounded(conn):
     client.emit_event("event", {"value": 1}, queue_name=permissive_name)
     client.drop_queue(permissive_name)
 
-    with pytest.raises(ValueError, match="Queue name must be provided"):
-        client.create_queue("   ")
+    whitespace_name = "   "
+    client.create_queue(whitespace_name)
+    client.emit_event("event", {"value": 1}, queue_name=whitespace_name)
+    client.drop_queue(whitespace_name)
 
     with pytest.raises(ValueError, match="too long"):
         client.drop_queue("q" * 58)
@@ -46,8 +48,10 @@ def test_async_queue_validation_is_permissive_but_bounded(db_dsn):
         await client.emit_event("event", {"value": 1}, queue_name=permissive_name)
         await client.drop_queue(permissive_name)
 
-        with pytest.raises(ValueError, match="Queue name must be provided"):
-            await client.create_queue("\t")
+        whitespace_name = "\t"
+        await client.create_queue(whitespace_name)
+        await client.emit_event("event", {"value": 1}, queue_name=whitespace_name)
+        await client.drop_queue(whitespace_name)
 
         with pytest.raises(ValueError, match="too long"):
             await client.emit_event("event", {"value": 1}, queue_name="q" * 58)

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1330,7 +1330,7 @@ export class Absurd {
 const MAX_QUEUE_NAME_LENGTH = 57;
 
 function validateQueueName(queueName: string): string {
-  if (!queueName || queueName.trim().length === 0) {
+  if (!queueName) {
     throw new Error("Queue name must be provided");
   }
   if (Buffer.byteLength(queueName, "utf8") > MAX_QUEUE_NAME_LENGTH) {

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -36,6 +36,20 @@ export interface SpawnOptions {
   idempotencyKey?: string;
 }
 
+export type QueueStorageMode = "unpartitioned" | "partitioned";
+
+export type QueueDetachMode = "none" | "empty";
+
+export interface CreateQueueOptions {
+  storageMode?: QueueStorageMode;
+  partitionLookahead?: string;
+  partitionLookback?: string;
+  cleanupTtlSeconds?: number;
+  cleanupLimit?: number;
+  detachMode?: QueueDetachMode;
+  detachMinAge?: string;
+}
+
 export interface RetryTaskOptions {
   queue?: string;
   maxAttempts?: number;
@@ -692,11 +706,64 @@ export class Absurd {
 
   /**
    * Creates a queue (defaults to this client's queue).
-   * @param queueName Queue name to create.
+   *
+   * Backward-compatible forms:
+   * - createQueue("name")
+   * - createQueue("name", { storageMode: "partitioned" })
    */
-  async createQueue(queueName?: string): Promise<void> {
+  async createQueue(
+    queueName?: string,
+    options: CreateQueueOptions = {},
+  ): Promise<void> {
     const queue = validateQueueName(queueName ?? this.queueName);
-    await this.con.query(`SELECT absurd.create_queue($1)`, [queue]);
+
+    let storageMode: QueueStorageMode = options.storageMode ?? "unpartitioned";
+
+    if (storageMode !== "unpartitioned" && storageMode !== "partitioned") {
+      throw new Error(`Invalid queue storage mode: ${String(storageMode)}`);
+    }
+
+    if (storageMode === "unpartitioned") {
+      await this.con.query(`SELECT absurd.create_queue($1)`, [queue]);
+    } else {
+      await this.con.query(`SELECT absurd.create_queue($1, $2)`, [
+        queue,
+        storageMode,
+      ]);
+    }
+
+    const policy: Record<string, unknown> = {};
+
+    if (options.partitionLookahead !== undefined) {
+      policy.partition_lookahead = options.partitionLookahead;
+    }
+
+    if (options.partitionLookback !== undefined) {
+      policy.partition_lookback = options.partitionLookback;
+    }
+
+    if (options.cleanupTtlSeconds !== undefined) {
+      policy.cleanup_ttl_seconds = options.cleanupTtlSeconds;
+    }
+
+    if (options.cleanupLimit !== undefined) {
+      policy.cleanup_limit = options.cleanupLimit;
+    }
+
+    if (options.detachMode !== undefined) {
+      policy.detach_mode = options.detachMode;
+    }
+
+    if (options.detachMinAge !== undefined) {
+      policy.detach_min_age = options.detachMinAge;
+    }
+
+    if (Object.keys(policy).length > 0) {
+      await this.con.query(`SELECT absurd.set_queue_policy($1, $2::jsonb)`, [
+        queue,
+        JSON.stringify(policy),
+      ]);
+    }
   }
 
   /**

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -43,7 +43,7 @@ export type QueueDetachMode = "none" | "empty";
 export interface QueuePolicyOptions {
   partitionLookahead?: string;
   partitionLookback?: string;
-  cleanupTtlSeconds?: number;
+  cleanupTtl?: string;
   cleanupLimit?: number;
   detachMode?: QueueDetachMode;
   detachMinAge?: string;
@@ -58,7 +58,7 @@ export interface QueuePolicy {
   storageMode: QueueStorageMode;
   partitionLookahead: string;
   partitionLookback: string;
-  cleanupTtlSeconds: number;
+  cleanupTtl: string;
   cleanupLimit: number;
   detachMode: QueueDetachMode;
   detachMinAge: string;
@@ -762,8 +762,8 @@ export class Absurd {
       policy.partition_lookback = options.partitionLookback;
     }
 
-    if (options.cleanupTtlSeconds !== undefined) {
-      policy.cleanup_ttl_seconds = options.cleanupTtlSeconds;
+    if (options.cleanupTtl !== undefined) {
+      policy.cleanup_ttl = options.cleanupTtl;
     }
 
     if (options.cleanupLimit !== undefined) {
@@ -810,7 +810,7 @@ export class Absurd {
       storage_mode: string;
       partition_lookahead: string;
       partition_lookback: string;
-      cleanup_ttl_seconds: number;
+      cleanup_ttl: string;
       cleanup_limit: number;
       detach_mode: string;
       detach_min_age: string;
@@ -821,7 +821,7 @@ export class Absurd {
           storage_mode,
           partition_lookahead::text,
           partition_lookback::text,
-          cleanup_ttl_seconds,
+          cleanup_ttl::text as cleanup_ttl,
           cleanup_limit,
           detach_mode,
           detach_min_age::text
@@ -841,7 +841,7 @@ export class Absurd {
       storageMode: row.storage_mode as QueueStorageMode,
       partitionLookahead: row.partition_lookahead,
       partitionLookback: row.partition_lookback,
-      cleanupTtlSeconds: row.cleanup_ttl_seconds,
+      cleanupTtl: row.cleanup_ttl,
       cleanupLimit: row.cleanup_limit,
       detachMode: row.detach_mode as QueueDetachMode,
       detachMinAge: row.detach_min_age,

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -40,14 +40,28 @@ export type QueueStorageMode = "unpartitioned" | "partitioned";
 
 export type QueueDetachMode = "none" | "empty";
 
-export interface CreateQueueOptions {
-  storageMode?: QueueStorageMode;
+export interface QueuePolicyOptions {
   partitionLookahead?: string;
   partitionLookback?: string;
   cleanupTtlSeconds?: number;
   cleanupLimit?: number;
   detachMode?: QueueDetachMode;
   detachMinAge?: string;
+}
+
+export interface CreateQueueOptions extends QueuePolicyOptions {
+  storageMode?: QueueStorageMode;
+}
+
+export interface QueuePolicy {
+  queueName: string;
+  storageMode: QueueStorageMode;
+  partitionLookahead: string;
+  partitionLookback: string;
+  cleanupTtlSeconds: number;
+  cleanupLimit: number;
+  detachMode: QueueDetachMode;
+  detachMinAge: string;
 }
 
 export interface RetryTaskOptions {
@@ -732,6 +746,12 @@ export class Absurd {
       ]);
     }
 
+    await this.setQueuePolicy(queue, options);
+  }
+
+  private buildQueuePolicyPayload(
+    options: QueuePolicyOptions,
+  ): Record<string, unknown> {
     const policy: Record<string, unknown> = {};
 
     if (options.partitionLookahead !== undefined) {
@@ -758,12 +778,74 @@ export class Absurd {
       policy.detach_min_age = options.detachMinAge;
     }
 
-    if (Object.keys(policy).length > 0) {
-      await this.con.query(`SELECT absurd.set_queue_policy($1, $2::jsonb)`, [
-        queue,
-        JSON.stringify(policy),
-      ]);
+    return policy;
+  }
+
+  /**
+   * Updates queue maintenance policy fields.
+   */
+  async setQueuePolicy(
+    queueName?: string,
+    options: QueuePolicyOptions = {},
+  ): Promise<void> {
+    const queue = validateQueueName(queueName ?? this.queueName);
+    const policy = this.buildQueuePolicyPayload(options);
+    if (Object.keys(policy).length === 0) {
+      return;
     }
+
+    await this.con.query(`SELECT absurd.set_queue_policy($1, $2::jsonb)`, [
+      queue,
+      JSON.stringify(policy),
+    ]);
+  }
+
+  /**
+   * Fetches queue maintenance policy fields.
+   */
+  async getQueuePolicy(queueName?: string): Promise<QueuePolicy | null> {
+    const queue = validateQueueName(queueName ?? this.queueName);
+    const result = await this.con.query<{
+      queue_name: string;
+      storage_mode: string;
+      partition_lookahead: string;
+      partition_lookback: string;
+      cleanup_ttl_seconds: number;
+      cleanup_limit: number;
+      detach_mode: string;
+      detach_min_age: string;
+    }>(
+      `
+        SELECT
+          queue_name,
+          storage_mode,
+          partition_lookahead::text,
+          partition_lookback::text,
+          cleanup_ttl_seconds,
+          cleanup_limit,
+          detach_mode,
+          detach_min_age::text
+        FROM absurd.get_queue_policy($1)
+      `,
+      [queue],
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+
+    return {
+      queueName: row.queue_name,
+      storageMode: row.storage_mode as QueueStorageMode,
+      partitionLookahead: row.partition_lookahead,
+      partitionLookback: row.partition_lookback,
+      cleanupTtlSeconds: row.cleanup_ttl_seconds,
+      cleanupLimit: row.cleanup_limit,
+      detachMode: row.detach_mode as QueueDetachMode,
+      detachMinAge: row.detach_min_age,
+    };
   }
 
   /**

--- a/sdks/typescript/test/basic.test.ts
+++ b/sdks/typescript/test/basic.test.ts
@@ -63,6 +63,93 @@ describe("Basic SDK Operations", () => {
         rows: [],
       });
     });
+
+    test("create queue supports partitioned storage mode option", async () => {
+      const queueName = randomName("partitioned_queue");
+      await absurd.createQueue(queueName, {
+        storageMode: "partitioned",
+      });
+
+      const parents = await ctx.pool.query<{
+        relname: string;
+        relkind: string;
+      }>(
+        `
+          SELECT c.relname, c.relkind
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = 'absurd'
+            AND c.relname IN ($1, $2, $3, $4, $5, $6)
+          ORDER BY c.relname
+        `,
+        [
+          `t_${queueName}`,
+          `r_${queueName}`,
+          `c_${queueName}`,
+          `w_${queueName}`,
+          `e_${queueName}`,
+          `i_${queueName}`,
+        ],
+      );
+
+      const relkinds = new Map(
+        parents.rows.map((row) => [row.relname, row.relkind]),
+      );
+      expect(relkinds.get(`t_${queueName}`)).toBe("p");
+      expect(relkinds.get(`r_${queueName}`)).toBe("p");
+      expect(relkinds.get(`c_${queueName}`)).toBe("p");
+      expect(relkinds.get(`w_${queueName}`)).toBe("p");
+      expect(relkinds.get(`e_${queueName}`)).toBe("r");
+      expect(relkinds.get(`i_${queueName}`)).toBe("r");
+
+      await absurd.dropQueue(queueName);
+    });
+
+    test("create queue supports policy options", async () => {
+      const queueName = randomName("policy_queue");
+      await absurd.createQueue(queueName, {
+        storageMode: "partitioned",
+        partitionLookahead: "35 days",
+        partitionLookback: "2 days",
+        cleanupTtlSeconds: 12345,
+        cleanupLimit: 77,
+        detachMode: "empty",
+        detachMinAge: "45 days",
+      });
+
+      const policy = await ctx.pool.query<{
+        partition_lookahead: string;
+        partition_lookback: string;
+        cleanup_ttl_seconds: number;
+        cleanup_limit: number;
+        detach_mode: string;
+        detach_min_age: string;
+      }>(
+        `
+          SELECT
+            partition_lookahead::text,
+            partition_lookback::text,
+            cleanup_ttl_seconds,
+            cleanup_limit,
+            detach_mode,
+            detach_min_age::text
+          FROM absurd.get_queue_policy($1)
+        `,
+        [queueName],
+      );
+
+      expect(policy.rows).toHaveLength(1);
+      expect(policy.rows[0]).toEqual({
+        partition_lookahead: "35 days",
+        partition_lookback: "2 days",
+        cleanup_ttl_seconds: 12345,
+        cleanup_limit: 77,
+        detach_mode: "empty",
+        detach_min_age: "45 days",
+      });
+
+      await absurd.dropQueue(queueName);
+    });
   });
 
   describe("Task spawning", () => {

--- a/sdks/typescript/test/basic.test.ts
+++ b/sdks/typescript/test/basic.test.ts
@@ -111,32 +111,31 @@ describe("Basic SDK Operations", () => {
         storageMode: "partitioned",
         partitionLookahead: "35 days",
         partitionLookback: "2 days",
-        cleanupTtlSeconds: 12345,
+        cleanupTtl: "12345 seconds",
         cleanupLimit: 77,
         detachMode: "empty",
         detachMinAge: "45 days",
       });
 
       const policy = await absurd.getQueuePolicy(queueName);
-      expect(policy).toEqual({
-        queueName,
-        storageMode: "partitioned",
-        partitionLookahead: "35 days",
-        partitionLookback: "2 days",
-        cleanupTtlSeconds: 12345,
-        cleanupLimit: 77,
-        detachMode: "empty",
-        detachMinAge: "45 days",
-      });
+      expect(policy).not.toBeNull();
+      expect(policy?.queueName).toBe(queueName);
+      expect(policy?.storageMode).toBe("partitioned");
+      expect(policy?.partitionLookahead).toBe("35 days");
+      expect(policy?.partitionLookback).toBe("2 days");
+      expect(policy?.cleanupTtl?.endsWith("3:25:45")).toBe(true);
+      expect(policy?.cleanupLimit).toBe(77);
+      expect(policy?.detachMode).toBe("empty");
+      expect(policy?.detachMinAge).toBe("45 days");
 
       await absurd.setQueuePolicy(queueName, {
-        cleanupTtlSeconds: 4321,
+        cleanupTtl: "4321 seconds",
         cleanupLimit: 12,
       });
 
       const updated = await absurd.getQueuePolicy(queueName);
       expect(updated).not.toBeNull();
-      expect(updated?.cleanupTtlSeconds).toBe(4321);
+      expect(updated?.cleanupTtl?.endsWith("1:12:01")).toBe(true);
       expect(updated?.cleanupLimit).toBe(12);
 
       await absurd.dropQueue(queueName);

--- a/sdks/typescript/test/basic.test.ts
+++ b/sdks/typescript/test/basic.test.ts
@@ -117,36 +117,27 @@ describe("Basic SDK Operations", () => {
         detachMinAge: "45 days",
       });
 
-      const policy = await ctx.pool.query<{
-        partition_lookahead: string;
-        partition_lookback: string;
-        cleanup_ttl_seconds: number;
-        cleanup_limit: number;
-        detach_mode: string;
-        detach_min_age: string;
-      }>(
-        `
-          SELECT
-            partition_lookahead::text,
-            partition_lookback::text,
-            cleanup_ttl_seconds,
-            cleanup_limit,
-            detach_mode,
-            detach_min_age::text
-          FROM absurd.get_queue_policy($1)
-        `,
-        [queueName],
-      );
-
-      expect(policy.rows).toHaveLength(1);
-      expect(policy.rows[0]).toEqual({
-        partition_lookahead: "35 days",
-        partition_lookback: "2 days",
-        cleanup_ttl_seconds: 12345,
-        cleanup_limit: 77,
-        detach_mode: "empty",
-        detach_min_age: "45 days",
+      const policy = await absurd.getQueuePolicy(queueName);
+      expect(policy).toEqual({
+        queueName,
+        storageMode: "partitioned",
+        partitionLookahead: "35 days",
+        partitionLookback: "2 days",
+        cleanupTtlSeconds: 12345,
+        cleanupLimit: 77,
+        detachMode: "empty",
+        detachMinAge: "45 days",
       });
+
+      await absurd.setQueuePolicy(queueName, {
+        cleanupTtlSeconds: 4321,
+        cleanupLimit: 12,
+      });
+
+      const updated = await absurd.getQueuePolicy(queueName);
+      expect(updated).not.toBeNull();
+      expect(updated?.cleanupTtlSeconds).toBe(4321);
+      expect(updated?.cleanupLimit).toBe(12);
 
       await absurd.dropQueue(queueName);
     });

--- a/sdks/typescript/test/queue-validation.test.ts
+++ b/sdks/typescript/test/queue-validation.test.ts
@@ -6,7 +6,7 @@ describe("Queue name validation", () => {
     const fakeCon = { query: async () => ({ rows: [] }) } as any;
 
     assert.throws(
-      () => new Absurd({ db: fakeCon, queueName: "   " }),
+      () => new Absurd({ db: fakeCon, queueName: "" }),
       /Queue name must be provided/,
     );
   });
@@ -22,7 +22,8 @@ describe("Queue name validation", () => {
     const absurd = new Absurd({ db: fakeCon, queueName: "default" });
 
     await absurd.createQueue("Queue Name-1");
-    expect(called).toBe(1);
+    await absurd.createQueue("   ");
+    expect(called).toBe(2);
   });
 
   test("rejects overlong queue names", async () => {
@@ -46,7 +47,7 @@ describe("Queue name validation", () => {
     const absurd = new Absurd({ db: fakeCon, queueName: "default" });
 
     await expect(
-      absurd.spawn("task", { value: 1 }, { queue: "\t" }),
+      absurd.spawn("task", { value: 1 }, { queue: "" }),
     ).rejects.toThrowError("Queue name must be provided");
     expect(called).toBe(0);
   });

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -394,13 +394,6 @@ create function absurd.drop_queue (p_queue_name text)
 as $$
 declare
   v_existing_queue text;
-  v_job_suffix text;
-  v_partition_job_name text;
-  v_cleanup_job_name text;
-  v_detach_plan_job_name text;
-  v_detach_run_pattern text;
-  v_drop_run_pattern text;
-  v_existing_job_id bigint;
 begin
   select queue_name into v_existing_queue
   from absurd.queues
@@ -410,41 +403,8 @@ begin
     return;
   end if;
 
-  -- If pg_cron is available, remove queue-scoped maintenance jobs so they
-  -- don't keep failing after the queue is dropped.
-  if to_regclass('cron.job') is not null
-     and exists (
-       select 1
-       from pg_proc p
-       join pg_namespace n on n.oid = p.pronamespace
-       where n.nspname = 'cron'
-         and p.proname = 'unschedule'
-     )
-  then
-    v_job_suffix := substr(md5(p_queue_name), 1, 12);
-    v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
-    v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
-    v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
-    v_detach_run_pattern := 'absurd_detach_run_' || v_job_suffix || '_%';
-    v_drop_run_pattern := 'absurd_drop_run_' || v_job_suffix || '_%';
-
-    for v_existing_job_id in
-      execute 'select jobid
-                 from cron.job
-                where jobname = $1
-                   or jobname = $2
-                   or jobname = $3
-                   or jobname like $4
-                   or jobname like $5'
-      using v_partition_job_name,
-            v_cleanup_job_name,
-            v_detach_plan_job_name,
-            v_detach_run_pattern,
-            v_drop_run_pattern
-    loop
-      execute 'select cron.unschedule($1)' using v_existing_job_id;
-    end loop;
-  end if;
+  -- Remove queue-scoped maintenance jobs.
+  perform absurd.disable_cron(p_queue_name);
 
   execute format('drop table if exists absurd.%I cascade', 'i_' || p_queue_name);
   execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -1683,3 +1683,97 @@ begin
   return encode(b, 'hex')::uuid;
 end;
 $$;
+
+-- Extracts the embedded timestamp from a UUIDv7 value.
+-- Returns NULL for non-v7 UUIDs.
+create function absurd.uuidv7_timestamp (p_id uuid)
+  returns timestamptz
+  language sql
+  immutable
+  strict
+as $$
+  with bytes as (
+    select uuid_send(p_id) as b
+  ),
+  decoded as (
+    select
+      (get_byte(b, 6) >> 4) as version,
+      ((get_byte(b, 0)::bigint << 40) |
+       (get_byte(b, 1)::bigint << 32) |
+       (get_byte(b, 2)::bigint << 24) |
+       (get_byte(b, 3)::bigint << 16) |
+       (get_byte(b, 4)::bigint << 8)  |
+        get_byte(b, 5)::bigint) as ts_ms
+    from bytes
+  )
+  select case
+           when version = 7 then 'epoch'::timestamptz + (ts_ms * interval '1 millisecond')
+           else null
+         end
+  from decoded;
+$$;
+
+-- Returns the lowest UUIDv7 value representable for the given timestamp.
+-- This is useful for time-window partition bounds over UUIDv7 keys.
+create function absurd.uuidv7_floor (p_ts timestamptz)
+  returns uuid
+  language plpgsql
+  immutable
+  strict
+as $$
+declare
+  ts_ms bigint := floor(extract(epoch from p_ts) * 1000)::bigint;
+  b bytea;
+  i int;
+begin
+  if ts_ms < 0 or ts_ms > 281474976710655 then
+    raise exception 'Timestamp "%" is outside UUIDv7 supported range', p_ts;
+  end if;
+
+  b := repeat(E'\\000', 16)::bytea;
+  for i in 0..5 loop
+    b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);
+  end loop;
+
+  -- Set UUIDv7 version and RFC4122 variant; keep all randomness bits at 0.
+  b := set_byte(b, 6, (7 << 4));
+  b := set_byte(b, 8, 128);
+
+  return encode(b, 'hex')::uuid;
+end;
+$$;
+
+-- Buckets a timestamp to ISO week start (Monday 00:00) in UTC.
+create function absurd.week_bucket_utc (p_ts timestamptz)
+  returns timestamptz
+  language sql
+  immutable
+  strict
+as $$
+  select date_trunc('week', p_ts at time zone 'UTC') at time zone 'UTC';
+$$;
+
+-- Returns a compact weekly partition tag in YWW format, where:
+-- * Y = last digit of the ISO year in UTC
+-- * WW = zero-padded ISO week number in UTC (01..53)
+--
+-- ISO weeks do not have week 0; days at year boundaries can belong
+-- to week 52/53 of the previous ISO year.
+--
+-- Examples:
+-- * 2024-01-01 UTC -> 401
+-- * 2021-01-01 UTC -> 053 (ISO week 53 of ISO year 2020)
+create function absurd.partition_week_tag (p_ts timestamptz)
+  returns text
+  language sql
+  immutable
+  strict
+as $$
+  with bucket as (
+    select absurd.week_bucket_utc(p_ts) at time zone 'UTC' as ts
+  )
+  select
+    ((extract(isoyear from ts)::int % 10)::text) ||
+    lpad((extract(week from ts)::int)::text, 2, '0')
+  from bucket;
+$$;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -394,6 +394,13 @@ create function absurd.drop_queue (p_queue_name text)
 as $$
 declare
   v_existing_queue text;
+  v_job_suffix text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_detach_run_pattern text;
+  v_drop_run_pattern text;
+  v_existing_job_id bigint;
 begin
   select queue_name into v_existing_queue
   from absurd.queues
@@ -401,6 +408,42 @@ begin
 
   if v_existing_queue is null then
     return;
+  end if;
+
+  -- If pg_cron is available, remove queue-scoped maintenance jobs so they
+  -- don't keep failing after the queue is dropped.
+  if to_regclass('cron.job') is not null
+     and exists (
+       select 1
+       from pg_proc p
+       join pg_namespace n on n.oid = p.pronamespace
+       where n.nspname = 'cron'
+         and p.proname = 'unschedule'
+     )
+  then
+    v_job_suffix := substr(md5(p_queue_name), 1, 12);
+    v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+    v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+    v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+    v_detach_run_pattern := 'absurd_detach_run_' || v_job_suffix || '_%';
+    v_drop_run_pattern := 'absurd_drop_run_' || v_job_suffix || '_%';
+
+    for v_existing_job_id in
+      execute 'select jobid
+                 from cron.job
+                where jobname = $1
+                   or jobname = $2
+                   or jobname = $3
+                   or jobname like $4
+                   or jobname like $5'
+      using v_partition_job_name,
+            v_cleanup_job_name,
+            v_detach_plan_job_name,
+            v_detach_run_pattern,
+            v_drop_run_pattern
+    loop
+      execute 'select cron.unschedule($1)' using v_existing_job_id;
+    end loop;
   end if;
 
   execute format('drop table if exists absurd.%I cascade', 'i_' || p_queue_name);

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -11,6 +11,7 @@
 -- * `c_` for checkpoints (saved states)
 -- * `e_` for emitted events
 -- * `w_` for wait registrations
+-- * `i_` for idempotency keys (partitioned queues only)
 --
 -- `create_queue`, `drop_queue`, and `list_queues` provide the management
 -- surface for provisioning queues safely.
@@ -54,7 +55,9 @@ $$;
 
 create table if not exists absurd.queues (
   queue_name text primary key,
-  created_at timestamptz not null default absurd.current_time()
+  created_at timestamptz not null default absurd.current_time(),
+  storage_mode text not null default 'unpartitioned'
+    check (storage_mode in ('unpartitioned', 'partitioned'))
 );
 
 -- Returns the Absurd schema release version baked into this SQL file.
@@ -93,63 +96,134 @@ create function absurd.ensure_queue_tables (p_queue_name text)
   returns void
   language plpgsql
 as $$
+declare
+  v_storage_mode text := 'unpartitioned';
 begin
   perform absurd.validate_queue_name(p_queue_name);
 
-  execute format(
-    'create table if not exists absurd.%I (
-        task_id uuid primary key,
-        task_name text not null,
-        params jsonb not null,
-        headers jsonb,
-        retry_strategy jsonb,
-        max_attempts integer,
-        cancellation jsonb,
-        enqueue_at timestamptz not null default absurd.current_time(),
-        first_started_at timestamptz,
-        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-        attempts integer not null default 0,
-        last_attempt_run uuid,
-        completed_payload jsonb,
-        cancelled_at timestamptz,
-        idempotency_key text unique
-     ) with (fillfactor=70)',
-    't_' || p_queue_name
-  );
+  select storage_mode into v_storage_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
 
-  execute format(
-    'create table if not exists absurd.%I (
-        run_id uuid primary key,
-        task_id uuid not null,
-        attempt integer not null,
-        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-        claimed_by text,
-        claim_expires_at timestamptz,
-        available_at timestamptz not null,
-        wake_event text,
-        event_payload jsonb,
-        started_at timestamptz,
-        completed_at timestamptz,
-        failed_at timestamptz,
-        result jsonb,
-        failure_reason jsonb,
-        created_at timestamptz not null default absurd.current_time()
-     ) with (fillfactor=70)',
-    'r_' || p_queue_name
-  );
+  v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
 
-  execute format(
-    'create table if not exists absurd.%I (
-        task_id uuid not null,
-        checkpoint_name text not null,
-        state jsonb,
-        status text not null default ''committed'',
-        owner_run_id uuid,
-        updated_at timestamptz not null default absurd.current_time(),
-        primary key (task_id, checkpoint_name)
-     ) with (fillfactor=70)',
-    'c_' || p_queue_name
-  );
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+  end if;
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          task_id uuid primary key,
+          task_name text not null,
+          params jsonb not null,
+          headers jsonb,
+          retry_strategy jsonb,
+          max_attempts integer,
+          cancellation jsonb,
+          enqueue_at timestamptz not null default absurd.current_time(),
+          first_started_at timestamptz,
+          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+          attempts integer not null default 0,
+          last_attempt_run uuid,
+          completed_payload jsonb,
+          cancelled_at timestamptz,
+          idempotency_key text
+       ) partition by range (task_id)',
+      't_' || p_queue_name
+    );
+  else
+    execute format(
+      'create table if not exists absurd.%I (
+          task_id uuid primary key,
+          task_name text not null,
+          params jsonb not null,
+          headers jsonb,
+          retry_strategy jsonb,
+          max_attempts integer,
+          cancellation jsonb,
+          enqueue_at timestamptz not null default absurd.current_time(),
+          first_started_at timestamptz,
+          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+          attempts integer not null default 0,
+          last_attempt_run uuid,
+          completed_payload jsonb,
+          cancelled_at timestamptz,
+          idempotency_key text unique
+       ) with (fillfactor=70)',
+      't_' || p_queue_name
+    );
+  end if;
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          run_id uuid primary key,
+          task_id uuid not null,
+          attempt integer not null,
+          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+          claimed_by text,
+          claim_expires_at timestamptz,
+          available_at timestamptz not null,
+          wake_event text,
+          event_payload jsonb,
+          started_at timestamptz,
+          completed_at timestamptz,
+          failed_at timestamptz,
+          result jsonb,
+          failure_reason jsonb,
+          created_at timestamptz not null default absurd.current_time()
+       ) partition by range (run_id)',
+      'r_' || p_queue_name
+    );
+
+    execute format(
+      'create table if not exists absurd.%I (
+          task_id uuid not null,
+          checkpoint_name text not null,
+          state jsonb,
+          status text not null default ''committed'',
+          owner_run_id uuid,
+          updated_at timestamptz not null default absurd.current_time(),
+          primary key (task_id, checkpoint_name)
+       ) partition by range (task_id)',
+      'c_' || p_queue_name
+    );
+  else
+    execute format(
+      'create table if not exists absurd.%I (
+          run_id uuid primary key,
+          task_id uuid not null,
+          attempt integer not null,
+          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+          claimed_by text,
+          claim_expires_at timestamptz,
+          available_at timestamptz not null,
+          wake_event text,
+          event_payload jsonb,
+          started_at timestamptz,
+          completed_at timestamptz,
+          failed_at timestamptz,
+          result jsonb,
+          failure_reason jsonb,
+          created_at timestamptz not null default absurd.current_time()
+       ) with (fillfactor=70)',
+      'r_' || p_queue_name
+    );
+
+    execute format(
+      'create table if not exists absurd.%I (
+          task_id uuid not null,
+          checkpoint_name text not null,
+          state jsonb,
+          status text not null default ''committed'',
+          owner_run_id uuid,
+          updated_at timestamptz not null default absurd.current_time(),
+          primary key (task_id, checkpoint_name)
+       ) with (fillfactor=70)',
+      'c_' || p_queue_name
+    );
+  end if;
 
   execute format(
     'create table if not exists absurd.%I (
@@ -160,18 +234,43 @@ begin
     'e_' || p_queue_name
   );
 
-  execute format(
-    'create table if not exists absurd.%I (
-        task_id uuid not null,
-        run_id uuid not null,
-        step_name text not null,
-        event_name text not null,
-        timeout_at timestamptz,
-        created_at timestamptz not null default absurd.current_time(),
-        primary key (run_id, step_name)
-     )',
-    'w_' || p_queue_name
-  );
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          task_id uuid not null,
+          run_id uuid not null,
+          step_name text not null,
+          event_name text not null,
+          timeout_at timestamptz,
+          created_at timestamptz not null default absurd.current_time(),
+          primary key (run_id, step_name)
+       ) partition by range (run_id)',
+      'w_' || p_queue_name
+    );
+  else
+    execute format(
+      'create table if not exists absurd.%I (
+          task_id uuid not null,
+          run_id uuid not null,
+          step_name text not null,
+          event_name text not null,
+          timeout_at timestamptz,
+          created_at timestamptz not null default absurd.current_time(),
+          primary key (run_id, step_name)
+       )',
+      'w_' || p_queue_name
+    );
+  end if;
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          idempotency_key text primary key,
+          task_id uuid not null
+       )',
+      'i_' || p_queue_name
+    );
+  end if;
 
   execute format(
     'create index if not exists %I on absurd.%I (state, available_at)',
@@ -210,27 +309,67 @@ begin
     ('e_' || p_queue_name) || '_eai',
     'e_' || p_queue_name
   );
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create index if not exists %I on absurd.%I (task_id)',
+      ('i_' || p_queue_name) || '_ti',
+      'i_' || p_queue_name
+    );
+
+    perform absurd.ensure_partitions(p_queue_name);
+  end if;
 end;
 $$;
 
--- Creates the queue with the given name.
+-- Creates the queue with the given name and storage mode.
 --
--- If the table already exists, the function returns silently.
-create function absurd.create_queue (p_queue_name text)
+-- Existing queues are idempotent as long as the requested mode matches.
+create function absurd.create_queue (
+  p_queue_name text,
+  p_storage_mode text
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_storage_mode text;
+  v_existing_mode text;
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  v_storage_mode := lower(trim(coalesce(p_storage_mode, '')));
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', p_storage_mode;
+  end if;
+
+  insert into absurd.queues (queue_name, storage_mode)
+  values (p_queue_name, v_storage_mode)
+  on conflict (queue_name) do nothing;
+
+  select storage_mode into v_existing_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
+
+  if v_existing_mode is null then
+    raise exception 'Queue "%" was not found after create attempt', p_queue_name;
+  end if;
+
+  if v_existing_mode <> v_storage_mode then
+    raise exception 'Queue "%" already exists with storage mode "%"', p_queue_name, v_existing_mode;
+  end if;
+
+  perform absurd.ensure_queue_tables(p_queue_name);
+end;
+$$;
+
+-- Creates an unpartitioned queue (backward-compatible API).
+create or replace function absurd.create_queue (p_queue_name text)
   returns void
   language plpgsql
 as $$
 begin
-  p_queue_name := absurd.validate_queue_name(p_queue_name);
-
-  begin
-    insert into absurd.queues (queue_name)
-    values (p_queue_name);
-  exception when unique_violation then
-    return;
-  end;
-
-  perform absurd.ensure_queue_tables(p_queue_name);
+  perform absurd.create_queue(p_queue_name, 'unpartitioned');
 end;
 $$;
 
@@ -252,6 +391,7 @@ begin
     return;
   end if;
 
+  execute format('drop table if exists absurd.%I cascade', 'i_' || p_queue_name);
   execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);
   execute format('drop table if exists absurd.%I cascade', 'e_' || p_queue_name);
   execute format('drop table if exists absurd.%I cascade', 'c_' || p_queue_name);
@@ -334,7 +474,11 @@ declare
   v_cancellation jsonb;
   v_idempotency_key text;
   v_existing_task_id uuid;
+  v_existing_run_id uuid;
+  v_existing_attempt integer;
   v_row_count integer;
+  v_storage_mode text := 'unpartitioned';
+  v_task_inserted boolean := false;
   v_now timestamptz := absurd.current_time();
   v_params jsonb := coalesce(p_params, 'null'::jsonb);
 begin
@@ -355,38 +499,92 @@ begin
     v_idempotency_key := p_options->>'idempotency_key';
   end if;
 
-  -- If idempotency_key is provided, use INSERT ... ON CONFLICT DO NOTHING
   if v_idempotency_key is not null then
+    select storage_mode into v_storage_mode
+    from absurd.queues
+    where queue_name = p_queue_name;
+
+    v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+    if v_storage_mode not in ('unpartitioned', 'partitioned') then
+      raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+    end if;
+
+    if v_storage_mode = 'partitioned' then
+      -- Reserve idempotency key via dedicated side table.
+      execute format(
+        'insert into absurd.%I (idempotency_key, task_id)
+         values ($1, $2)
+         on conflict (idempotency_key) do nothing',
+        'i_' || p_queue_name
+      )
+      using v_idempotency_key, v_task_id;
+
+      get diagnostics v_row_count = row_count;
+
+      if v_row_count = 0 then
+        execute format(
+          'select task_id
+             from absurd.%I
+            where idempotency_key = $1',
+          'i_' || p_queue_name
+        )
+        into v_existing_task_id
+        using v_idempotency_key;
+
+        execute format(
+          'select last_attempt_run, attempts
+             from absurd.%I
+            where task_id = $1',
+          't_' || p_queue_name
+        )
+        into v_existing_run_id, v_existing_attempt
+        using v_existing_task_id;
+
+        if v_existing_task_id is null or v_existing_run_id is null then
+          raise exception 'Idempotency key "%" is inconsistent in queue "%"', v_idempotency_key, p_queue_name;
+        end if;
+
+        return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+        return;
+      end if;
+    else
+      -- Unpartitioned queues keep the original unique(idempotency_key)
+      -- behavior directly on t_<queue>.
+      execute format(
+        'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
+         values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
+         on conflict (idempotency_key) do nothing',
+        't_' || p_queue_name
+      )
+      using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
+
+      get diagnostics v_row_count = row_count;
+
+      if v_row_count = 0 then
+        execute format(
+          'select task_id, last_attempt_run, attempts
+             from absurd.%I
+            where idempotency_key = $1',
+          't_' || p_queue_name
+        )
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
+
+        return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;
+        return;
+      end if;
+
+      v_task_inserted := true;
+    end if;
+  end if;
+
+  if not v_task_inserted then
     execute format(
       'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
-       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)
-       on conflict (idempotency_key) do nothing',
+       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, $11)',
       't_' || p_queue_name
     )
     using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id, v_idempotency_key;
-
-    get diagnostics v_row_count = row_count;
-
-    if v_row_count = 0 then
-      -- Task already exists, look up existing task info
-      execute format(
-        'select task_id, last_attempt_run, attempts from absurd.%I where idempotency_key = $1',
-        't_' || p_queue_name
-      )
-      into v_existing_task_id, v_run_id, v_attempt
-      using v_idempotency_key;
-
-      return query select v_existing_task_id, v_run_id, v_attempt, false;
-      return;
-    end if;
-  else
-    -- No idempotency key, insert normally
-    execute format(
-      'insert into absurd.%I (task_id, task_name, params, headers, retry_strategy, max_attempts, cancellation, enqueue_at, first_started_at, state, attempts, last_attempt_run, completed_payload, cancelled_at, idempotency_key)
-       values ($1, $2, $3, $4, $5, $6, $7, $8, null, ''pending'', $9, $10, null, null, null)',
-      't_' || p_queue_name
-    )
-    using v_task_id, p_task_name, v_params, v_headers, v_retry_strategy, v_max_attempts, v_cancellation, v_now, v_attempt, v_run_id;
   end if;
 
   execute format(
@@ -1546,6 +1744,7 @@ declare
   v_now timestamptz := absurd.current_time();
   v_cutoff timestamptz;
   v_deleted_count integer;
+  v_storage_mode text := 'unpartitioned';
 begin
   if p_ttl_seconds is null or p_ttl_seconds < 0 then
     raise exception 'TTL must be a non-negative number of seconds';
@@ -1553,54 +1752,116 @@ begin
 
   v_cutoff := v_now - (p_ttl_seconds * interval '1 second');
 
-  -- Delete in order: wait registrations, checkpoints, runs, then tasks
-  -- Use a CTE to find eligible tasks and delete their related data
-  execute format(
-    'with eligible_tasks as (
-        select t.task_id,
-               case
-                 when t.state = ''completed'' then r.completed_at
-                 when t.state = ''failed'' then r.failed_at
-                 when t.state = ''cancelled'' then t.cancelled_at
-                 else null
-               end as terminal_at
-          from absurd.%1$I t
-          left join absurd.%2$I r on r.run_id = t.last_attempt_run
-         where t.state in (''completed'', ''failed'', ''cancelled'')
-     ),
-     to_delete as (
-        select task_id
-          from eligible_tasks
-         where terminal_at is not null
-           and terminal_at < $1
-         order by terminal_at
-         limit $2
-     ),
-     del_waits as (
-        delete from absurd.%3$I w
-         where w.task_id in (select task_id from to_delete)
-     ),
-     del_checkpoints as (
-        delete from absurd.%4$I c
-         where c.task_id in (select task_id from to_delete)
-     ),
-     del_runs as (
-        delete from absurd.%2$I r
-         where r.task_id in (select task_id from to_delete)
-     ),
-     del_tasks as (
-        delete from absurd.%1$I t
-         where t.task_id in (select task_id from to_delete)
-         returning 1
-     )
-     select count(*) from del_tasks',
-    't_' || p_queue_name,
-    'r_' || p_queue_name,
-    'w_' || p_queue_name,
-    'c_' || p_queue_name
-  )
-  into v_deleted_count
-  using v_cutoff, p_limit;
+  select storage_mode into v_storage_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
+
+  v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+
+  if v_storage_mode = 'partitioned' then
+    -- Delete in order: wait registrations, checkpoints, runs, idempotency keys,
+    -- then tasks.
+    execute format(
+      'with eligible_tasks as (
+          select t.task_id,
+                 case
+                   when t.state = ''completed'' then r.completed_at
+                   when t.state = ''failed'' then r.failed_at
+                   when t.state = ''cancelled'' then t.cancelled_at
+                   else null
+                 end as terminal_at
+            from absurd.%1$I t
+            left join absurd.%2$I r on r.run_id = t.last_attempt_run
+           where t.state in (''completed'', ''failed'', ''cancelled'')
+       ),
+       to_delete as (
+          select task_id
+            from eligible_tasks
+           where terminal_at is not null
+             and terminal_at < $1
+           order by terminal_at
+           limit $2
+       ),
+       del_waits as (
+          delete from absurd.%3$I w
+           where w.task_id in (select task_id from to_delete)
+       ),
+       del_checkpoints as (
+          delete from absurd.%4$I c
+           where c.task_id in (select task_id from to_delete)
+       ),
+       del_runs as (
+          delete from absurd.%2$I r
+           where r.task_id in (select task_id from to_delete)
+       ),
+       del_idempotency as (
+          delete from absurd.%5$I i
+           where i.task_id in (select task_id from to_delete)
+       ),
+       del_tasks as (
+          delete from absurd.%1$I t
+           where t.task_id in (select task_id from to_delete)
+           returning 1
+       )
+       select count(*) from del_tasks',
+      't_' || p_queue_name,
+      'r_' || p_queue_name,
+      'w_' || p_queue_name,
+      'c_' || p_queue_name,
+      'i_' || p_queue_name
+    )
+    into v_deleted_count
+    using v_cutoff, p_limit;
+  else
+    -- Unpartitioned queues keep idempotency key ownership on the task row,
+    -- so no side-table cleanup is needed.
+    execute format(
+      'with eligible_tasks as (
+          select t.task_id,
+                 case
+                   when t.state = ''completed'' then r.completed_at
+                   when t.state = ''failed'' then r.failed_at
+                   when t.state = ''cancelled'' then t.cancelled_at
+                   else null
+                 end as terminal_at
+            from absurd.%1$I t
+            left join absurd.%2$I r on r.run_id = t.last_attempt_run
+           where t.state in (''completed'', ''failed'', ''cancelled'')
+       ),
+       to_delete as (
+          select task_id
+            from eligible_tasks
+           where terminal_at is not null
+             and terminal_at < $1
+           order by terminal_at
+           limit $2
+       ),
+       del_waits as (
+          delete from absurd.%3$I w
+           where w.task_id in (select task_id from to_delete)
+       ),
+       del_checkpoints as (
+          delete from absurd.%4$I c
+           where c.task_id in (select task_id from to_delete)
+       ),
+       del_runs as (
+          delete from absurd.%2$I r
+           where r.task_id in (select task_id from to_delete)
+       ),
+       del_tasks as (
+          delete from absurd.%1$I t
+           where t.task_id in (select task_id from to_delete)
+           returning 1
+       )
+       select count(*) from del_tasks',
+      't_' || p_queue_name,
+      'r_' || p_queue_name,
+      'w_' || p_queue_name,
+      'c_' || p_queue_name
+    )
+    into v_deleted_count
+    using v_cutoff, p_limit;
+  end if;
 
   return v_deleted_count;
 end;
@@ -1776,4 +2037,129 @@ as $$
     ((extract(isoyear from ts)::int % 10)::text) ||
     lpad((extract(week from ts)::int)::text, 2, '0')
   from bucket;
+$$;
+
+-- Ensures weekly UUIDv7 partitions exist for partitioned queues.
+--
+-- By default this creates partitions for:
+-- * the week containing now()
+-- * the previous week if now() is within 1 day of a week boundary
+--
+-- p_until can be provided to pre-create partitions up to a future timestamp.
+create function absurd.ensure_partitions (
+  p_queue_name text default null,
+  p_until timestamptz default null,
+  p_clock_skew interval default interval '1 day'
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_now timestamptz := absurd.current_time();
+  v_until timestamptz := coalesce(p_until, absurd.current_time());
+  v_skew interval := coalesce(p_clock_skew, interval '1 day');
+  v_window_start timestamptz;
+  v_window_end timestamptz;
+  v_week_start timestamptz;
+  v_week_end timestamptz;
+  v_partition_tag text;
+  v_uuid_from uuid;
+  v_uuid_to uuid;
+  v_queue record;
+begin
+  if v_skew < interval '0 seconds' then
+    raise exception 'clock skew tolerance must be non-negative';
+  end if;
+
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues
+      where queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  if v_until < v_now then
+    v_until := v_now;
+  end if;
+
+  v_window_start := absurd.week_bucket_utc(v_now - v_skew);
+  v_window_end := absurd.week_bucket_utc(v_until);
+
+  for v_queue in
+    select queue_name
+    from absurd.queues
+    where storage_mode = 'partitioned'
+      and (p_queue_name is null or queue_name = p_queue_name)
+    order by queue_name
+  loop
+    execute format(
+      'create table if not exists absurd.%I partition of absurd.%I default',
+      't_' || v_queue.queue_name || '_d',
+      't_' || v_queue.queue_name
+    );
+    execute format(
+      'create table if not exists absurd.%I partition of absurd.%I default',
+      'r_' || v_queue.queue_name || '_d',
+      'r_' || v_queue.queue_name
+    );
+    execute format(
+      'create table if not exists absurd.%I partition of absurd.%I default',
+      'c_' || v_queue.queue_name || '_d',
+      'c_' || v_queue.queue_name
+    );
+    execute format(
+      'create table if not exists absurd.%I partition of absurd.%I default',
+      'w_' || v_queue.queue_name || '_d',
+      'w_' || v_queue.queue_name
+    );
+
+    v_week_start := v_window_start;
+    while v_week_start <= v_window_end loop
+      v_week_end := v_week_start + interval '7 days';
+      v_partition_tag := absurd.partition_week_tag(v_week_start);
+      v_uuid_from := absurd.uuidv7_floor(v_week_start);
+      v_uuid_to := absurd.uuidv7_floor(v_week_end);
+
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        't_' || v_queue.queue_name || '_' || v_partition_tag,
+        't_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        'r_' || v_queue.queue_name || '_' || v_partition_tag,
+        'r_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        'c_' || v_queue.queue_name || '_' || v_partition_tag,
+        'c_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I
+         for values from (%L::uuid) to (%L::uuid)',
+        'w_' || v_queue.queue_name || '_' || v_partition_tag,
+        'w_' || v_queue.queue_name,
+        v_uuid_from,
+        v_uuid_to
+      );
+
+      v_week_start := v_week_end;
+    end loop;
+  end loop;
+end;
 $$;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -62,8 +62,8 @@ create table if not exists absurd.queues (
     check (partition_lookahead >= interval '0 seconds'),
   partition_lookback interval not null default interval '1 day'
     check (partition_lookback >= interval '0 seconds'),
-  cleanup_ttl_seconds integer not null default (30 * 86400)
-    check (cleanup_ttl_seconds >= 0),
+  cleanup_ttl interval not null default interval '30 days'
+    check (cleanup_ttl >= interval '0 seconds'),
   cleanup_limit integer not null default 1000
     check (cleanup_limit >= 1),
   detach_mode text not null default 'none'
@@ -431,7 +431,7 @@ create function absurd.get_queue_policy (
     storage_mode text,
     partition_lookahead interval,
     partition_lookback interval,
-    cleanup_ttl_seconds integer,
+    cleanup_ttl interval,
     cleanup_limit integer,
     detach_mode text,
     detach_min_age interval
@@ -443,7 +443,7 @@ as $$
     q.storage_mode,
     q.partition_lookahead,
     q.partition_lookback,
-    q.cleanup_ttl_seconds,
+    q.cleanup_ttl,
     q.cleanup_limit,
     q.detach_mode,
     q.detach_min_age
@@ -456,7 +456,7 @@ $$;
 -- p_policy accepts optional keys:
 -- * partition_lookahead (interval text)
 -- * partition_lookback (interval text)
--- * cleanup_ttl_seconds (integer >= 0)
+-- * cleanup_ttl (interval text, >= 0)
 -- * cleanup_limit (integer >= 1)
 -- * detach_mode ('none' | 'empty')
 -- * detach_min_age (interval text)
@@ -474,7 +474,7 @@ declare
 
   v_partition_lookahead interval;
   v_partition_lookback interval;
-  v_cleanup_ttl_seconds integer;
+  v_cleanup_ttl interval;
   v_cleanup_limit integer;
   v_detach_mode text;
   v_detach_min_age interval;
@@ -491,7 +491,7 @@ begin
    where k.key not in (
       'partition_lookahead',
       'partition_lookback',
-      'cleanup_ttl_seconds',
+      'cleanup_ttl',
       'cleanup_limit',
       'detach_mode',
       'detach_min_age'
@@ -516,14 +516,14 @@ begin
   select
     partition_lookahead,
     partition_lookback,
-    cleanup_ttl_seconds,
+    cleanup_ttl,
     cleanup_limit,
     detach_mode,
     detach_min_age
   into
     v_partition_lookahead,
     v_partition_lookback,
-    v_cleanup_ttl_seconds,
+    v_cleanup_ttl,
     v_cleanup_limit,
     v_detach_mode,
     v_detach_min_age
@@ -539,8 +539,8 @@ begin
     v_partition_lookback := (v_policy->>'partition_lookback')::interval;
   end if;
 
-  if v_policy ? 'cleanup_ttl_seconds' then
-    v_cleanup_ttl_seconds := (v_policy->>'cleanup_ttl_seconds')::integer;
+  if v_policy ? 'cleanup_ttl' then
+    v_cleanup_ttl := (v_policy->>'cleanup_ttl')::interval;
   end if;
 
   if v_policy ? 'cleanup_limit' then
@@ -563,8 +563,8 @@ begin
     raise exception 'partition_lookback must be non-negative';
   end if;
 
-  if v_cleanup_ttl_seconds < 0 then
-    raise exception 'cleanup_ttl_seconds must be non-negative';
+  if v_cleanup_ttl < interval '0 seconds' then
+    raise exception 'cleanup_ttl must be non-negative';
   end if;
 
   if v_cleanup_limit < 1 then
@@ -582,7 +582,7 @@ begin
   update absurd.queues
      set partition_lookahead = v_partition_lookahead,
          partition_lookback = v_partition_lookback,
-         cleanup_ttl_seconds = v_cleanup_ttl_seconds,
+         cleanup_ttl = v_cleanup_ttl,
          cleanup_limit = v_cleanup_limit,
          detach_mode = v_detach_mode,
          detach_min_age = v_detach_min_age
@@ -1921,6 +1921,7 @@ create function absurd.cleanup_all_queues (
 as $$
 declare
   v_queue record;
+  v_cleanup_ttl_seconds integer;
 begin
   if p_queue_name is not null then
     p_queue_name := absurd.validate_queue_name(p_queue_name);
@@ -1937,21 +1938,26 @@ begin
   for v_queue in
     select
       q.queue_name,
-      q.cleanup_ttl_seconds,
+      q.cleanup_ttl,
       q.cleanup_limit
     from absurd.queues q
     where p_queue_name is null or q.queue_name = p_queue_name
     order by q.queue_name
   loop
+    v_cleanup_ttl_seconds := greatest(
+      floor(extract(epoch from v_queue.cleanup_ttl))::integer,
+      0
+    );
+
     queue_name := v_queue.queue_name;
     tasks_deleted := absurd.cleanup_tasks(
       v_queue.queue_name,
-      v_queue.cleanup_ttl_seconds,
+      v_cleanup_ttl_seconds,
       v_queue.cleanup_limit
     );
     events_deleted := absurd.cleanup_events(
       v_queue.queue_name,
-      v_queue.cleanup_ttl_seconds,
+      v_cleanup_ttl_seconds,
       v_queue.cleanup_limit
     );
     return next;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -112,6 +112,11 @@ create function absurd.ensure_queue_tables (p_queue_name text)
 as $$
 declare
   v_storage_mode text := 'unpartitioned';
+  v_t_suffix text;
+  v_r_suffix text;
+  v_c_suffix text;
+  v_w_suffix text;
+  v_t_idempotency_def text;
 begin
   perform absurd.validate_queue_name(p_queue_name);
 
@@ -126,118 +131,77 @@ begin
   end if;
 
   if v_storage_mode = 'partitioned' then
-    execute format(
-      'create table if not exists absurd.%I (
-          task_id uuid primary key,
-          task_name text not null,
-          params jsonb not null,
-          headers jsonb,
-          retry_strategy jsonb,
-          max_attempts integer,
-          cancellation jsonb,
-          enqueue_at timestamptz not null default absurd.current_time(),
-          first_started_at timestamptz,
-          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-          attempts integer not null default 0,
-          last_attempt_run uuid,
-          completed_payload jsonb,
-          cancelled_at timestamptz,
-          idempotency_key text
-       ) partition by range (task_id)',
-      't_' || p_queue_name
-    );
+    v_t_suffix := 'partition by range (task_id)';
+    v_r_suffix := 'partition by range (run_id)';
+    v_c_suffix := 'partition by range (task_id)';
+    v_w_suffix := 'partition by range (run_id)';
+    v_t_idempotency_def := 'idempotency_key text';
   else
-    execute format(
-      'create table if not exists absurd.%I (
-          task_id uuid primary key,
-          task_name text not null,
-          params jsonb not null,
-          headers jsonb,
-          retry_strategy jsonb,
-          max_attempts integer,
-          cancellation jsonb,
-          enqueue_at timestamptz not null default absurd.current_time(),
-          first_started_at timestamptz,
-          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-          attempts integer not null default 0,
-          last_attempt_run uuid,
-          completed_payload jsonb,
-          cancelled_at timestamptz,
-          idempotency_key text unique
-       ) with (fillfactor=70)',
-      't_' || p_queue_name
-    );
+    v_t_suffix := 'with (fillfactor=70)';
+    v_r_suffix := 'with (fillfactor=70)';
+    v_c_suffix := 'with (fillfactor=70)';
+    v_w_suffix := '';
+    v_t_idempotency_def := 'idempotency_key text unique';
   end if;
 
-  if v_storage_mode = 'partitioned' then
-    execute format(
-      'create table if not exists absurd.%I (
-          run_id uuid primary key,
-          task_id uuid not null,
-          attempt integer not null,
-          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-          claimed_by text,
-          claim_expires_at timestamptz,
-          available_at timestamptz not null,
-          wake_event text,
-          event_payload jsonb,
-          started_at timestamptz,
-          completed_at timestamptz,
-          failed_at timestamptz,
-          result jsonb,
-          failure_reason jsonb,
-          created_at timestamptz not null default absurd.current_time()
-       ) partition by range (run_id)',
-      'r_' || p_queue_name
-    );
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid primary key,
+        task_name text not null,
+        params jsonb not null,
+        headers jsonb,
+        retry_strategy jsonb,
+        max_attempts integer,
+        cancellation jsonb,
+        enqueue_at timestamptz not null default absurd.current_time(),
+        first_started_at timestamptz,
+        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+        attempts integer not null default 0,
+        last_attempt_run uuid,
+        completed_payload jsonb,
+        cancelled_at timestamptz,
+        %s
+     ) %s',
+    't_' || p_queue_name,
+    v_t_idempotency_def,
+    v_t_suffix
+  );
 
-    execute format(
-      'create table if not exists absurd.%I (
-          task_id uuid not null,
-          checkpoint_name text not null,
-          state jsonb,
-          status text not null default ''committed'',
-          owner_run_id uuid,
-          updated_at timestamptz not null default absurd.current_time(),
-          primary key (task_id, checkpoint_name)
-       ) partition by range (task_id)',
-      'c_' || p_queue_name
-    );
-  else
-    execute format(
-      'create table if not exists absurd.%I (
-          run_id uuid primary key,
-          task_id uuid not null,
-          attempt integer not null,
-          state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
-          claimed_by text,
-          claim_expires_at timestamptz,
-          available_at timestamptz not null,
-          wake_event text,
-          event_payload jsonb,
-          started_at timestamptz,
-          completed_at timestamptz,
-          failed_at timestamptz,
-          result jsonb,
-          failure_reason jsonb,
-          created_at timestamptz not null default absurd.current_time()
-       ) with (fillfactor=70)',
-      'r_' || p_queue_name
-    );
+  execute format(
+    'create table if not exists absurd.%I (
+        run_id uuid primary key,
+        task_id uuid not null,
+        attempt integer not null,
+        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+        claimed_by text,
+        claim_expires_at timestamptz,
+        available_at timestamptz not null,
+        wake_event text,
+        event_payload jsonb,
+        started_at timestamptz,
+        completed_at timestamptz,
+        failed_at timestamptz,
+        result jsonb,
+        failure_reason jsonb,
+        created_at timestamptz not null default absurd.current_time()
+     ) %s',
+    'r_' || p_queue_name,
+    v_r_suffix
+  );
 
-    execute format(
-      'create table if not exists absurd.%I (
-          task_id uuid not null,
-          checkpoint_name text not null,
-          state jsonb,
-          status text not null default ''committed'',
-          owner_run_id uuid,
-          updated_at timestamptz not null default absurd.current_time(),
-          primary key (task_id, checkpoint_name)
-       ) with (fillfactor=70)',
-      'c_' || p_queue_name
-    );
-  end if;
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid not null,
+        checkpoint_name text not null,
+        state jsonb,
+        status text not null default ''committed'',
+        owner_run_id uuid,
+        updated_at timestamptz not null default absurd.current_time(),
+        primary key (task_id, checkpoint_name)
+     ) %s',
+    'c_' || p_queue_name,
+    v_c_suffix
+  );
 
   execute format(
     'create table if not exists absurd.%I (
@@ -248,33 +212,19 @@ begin
     'e_' || p_queue_name
   );
 
-  if v_storage_mode = 'partitioned' then
-    execute format(
-      'create table if not exists absurd.%I (
-          task_id uuid not null,
-          run_id uuid not null,
-          step_name text not null,
-          event_name text not null,
-          timeout_at timestamptz,
-          created_at timestamptz not null default absurd.current_time(),
-          primary key (run_id, step_name)
-       ) partition by range (run_id)',
-      'w_' || p_queue_name
-    );
-  else
-    execute format(
-      'create table if not exists absurd.%I (
-          task_id uuid not null,
-          run_id uuid not null,
-          step_name text not null,
-          event_name text not null,
-          timeout_at timestamptz,
-          created_at timestamptz not null default absurd.current_time(),
-          primary key (run_id, step_name)
-       )',
-      'w_' || p_queue_name
-    );
-  end if;
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid not null,
+        run_id uuid not null,
+        step_name text not null,
+        event_name text not null,
+        timeout_at timestamptz,
+        created_at timestamptz not null default absurd.current_time(),
+        primary key (run_id, step_name)
+     ) %s',
+    'w_' || p_queue_name,
+    v_w_suffix
+  );
 
   if v_storage_mode = 'partitioned' then
     execute format(

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -2403,7 +2403,6 @@ create function absurd.list_detach_candidates (
     queue_name text,
     parent_table text,
     partition_table text,
-    candidate_hash text,
     detach_sql text,
     drop_sql text
   )
@@ -2500,7 +2499,6 @@ begin
         queue_name := v_queue.queue_name;
         parent_table := v_parent_table;
         partition_table := v_part.partition_name;
-        candidate_hash := substr(md5(v_parent_table || ':' || v_part.partition_name), 1, 12);
         detach_sql := format(
           'alter table absurd.%I detach partition absurd.%I concurrently',
           v_parent_table,
@@ -2609,6 +2607,7 @@ as $$
 declare
   v_scope text;
   v_candidate record;
+  v_candidate_key text;
   v_detach_job_name text;
   v_drop_job_name text;
   v_detach_command text;
@@ -2664,22 +2663,28 @@ begin
     from absurd.list_detach_candidates(p_queue_name) c
     order by c.queue_name, c.parent_table, c.partition_table
   loop
+    v_candidate_key := substr(
+      md5(v_candidate.parent_table || ':' || v_candidate.partition_table),
+      1,
+      12
+    );
+
     v_detach_job_name := format(
       'absurd_detach_run_%s_%s',
       v_scope,
-      v_candidate.candidate_hash
+      v_candidate_key
     );
     v_drop_job_name := format(
       'absurd_drop_run_%s_%s',
       v_scope,
-      v_candidate.candidate_hash
+      v_candidate_key
     );
 
     if not exists (
       select 1
       from cron.job
       where jobname = v_detach_job_name
-         or jobname like ('absurd_detach_run_%_' || v_candidate.candidate_hash)
+         or jobname like ('absurd_detach_run_%_' || v_candidate_key)
     ) then
       v_detach_command := format(
         '%s; select cron.unschedule(jobid) from cron.job where jobname = %L;',
@@ -2703,7 +2708,7 @@ begin
       select 1
       from cron.job
       where jobname = v_drop_job_name
-         or jobname like ('absurd_drop_run_%_' || v_candidate.candidate_hash)
+         or jobname like ('absurd_drop_run_%_' || v_candidate_key)
     ) then
       v_drop_command := format(
         'select absurd.drop_detached_partition(%L, %L);',

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -57,7 +57,19 @@ create table if not exists absurd.queues (
   queue_name text primary key,
   created_at timestamptz not null default absurd.current_time(),
   storage_mode text not null default 'unpartitioned'
-    check (storage_mode in ('unpartitioned', 'partitioned'))
+    check (storage_mode in ('unpartitioned', 'partitioned')),
+  partition_lookahead interval not null default interval '28 days'
+    check (partition_lookahead >= interval '0 seconds'),
+  partition_lookback interval not null default interval '1 day'
+    check (partition_lookback >= interval '0 seconds'),
+  cleanup_ttl_seconds integer not null default (30 * 86400)
+    check (cleanup_ttl_seconds >= 0),
+  cleanup_limit integer not null default 1000
+    check (cleanup_limit >= 1),
+  detach_mode text not null default 'none'
+    check (detach_mode in ('none', 'empty')),
+  detach_min_age interval not null default interval '30 days'
+    check (detach_min_age >= interval '0 seconds')
 );
 
 -- Returns the Absurd schema release version baked into this SQL file.
@@ -408,6 +420,174 @@ create function absurd.list_queues ()
   language sql
 as $$
   select queue_name from absurd.queues order by queue_name;
+$$;
+
+-- Returns queue maintenance policy metadata.
+create function absurd.get_queue_policy (
+  p_queue_name text
+)
+  returns table (
+    queue_name text,
+    storage_mode text,
+    partition_lookahead interval,
+    partition_lookback interval,
+    cleanup_ttl_seconds integer,
+    cleanup_limit integer,
+    detach_mode text,
+    detach_min_age interval
+  )
+  language sql
+as $$
+  select
+    q.queue_name,
+    q.storage_mode,
+    q.partition_lookahead,
+    q.partition_lookback,
+    q.cleanup_ttl_seconds,
+    q.cleanup_limit,
+    q.detach_mode,
+    q.detach_min_age
+  from absurd.queues q
+  where q.queue_name = p_queue_name;
+$$;
+
+-- Updates queue maintenance policy metadata.
+--
+-- p_policy accepts optional keys:
+-- * partition_lookahead (interval text)
+-- * partition_lookback (interval text)
+-- * cleanup_ttl_seconds (integer >= 0)
+-- * cleanup_limit (integer >= 1)
+-- * detach_mode ('none' | 'empty')
+-- * detach_min_age (interval text)
+create function absurd.set_queue_policy (
+  p_queue_name text,
+  p_policy jsonb
+)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_policy jsonb := coalesce(p_policy, '{}'::jsonb);
+  v_unknown_key text;
+  v_exists boolean := false;
+
+  v_partition_lookahead interval;
+  v_partition_lookback interval;
+  v_cleanup_ttl_seconds integer;
+  v_cleanup_limit integer;
+  v_detach_mode text;
+  v_detach_min_age interval;
+begin
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  if jsonb_typeof(v_policy) <> 'object' then
+    raise exception 'Queue policy must be a JSON object';
+  end if;
+
+  select k.key
+    into v_unknown_key
+    from jsonb_object_keys(v_policy) as k(key)
+   where k.key not in (
+      'partition_lookahead',
+      'partition_lookback',
+      'cleanup_ttl_seconds',
+      'cleanup_limit',
+      'detach_mode',
+      'detach_min_age'
+   )
+   limit 1;
+
+  if v_unknown_key is not null then
+    raise exception 'Unsupported queue policy key "%"', v_unknown_key;
+  end if;
+
+  select exists (
+    select 1
+    from absurd.queues
+    where queue_name = p_queue_name
+  )
+  into v_exists;
+
+  if not v_exists then
+    raise exception 'Queue "%" does not exist', p_queue_name;
+  end if;
+
+  select
+    partition_lookahead,
+    partition_lookback,
+    cleanup_ttl_seconds,
+    cleanup_limit,
+    detach_mode,
+    detach_min_age
+  into
+    v_partition_lookahead,
+    v_partition_lookback,
+    v_cleanup_ttl_seconds,
+    v_cleanup_limit,
+    v_detach_mode,
+    v_detach_min_age
+  from absurd.queues
+  where queue_name = p_queue_name
+  for update;
+
+  if v_policy ? 'partition_lookahead' then
+    v_partition_lookahead := (v_policy->>'partition_lookahead')::interval;
+  end if;
+
+  if v_policy ? 'partition_lookback' then
+    v_partition_lookback := (v_policy->>'partition_lookback')::interval;
+  end if;
+
+  if v_policy ? 'cleanup_ttl_seconds' then
+    v_cleanup_ttl_seconds := (v_policy->>'cleanup_ttl_seconds')::integer;
+  end if;
+
+  if v_policy ? 'cleanup_limit' then
+    v_cleanup_limit := (v_policy->>'cleanup_limit')::integer;
+  end if;
+
+  if v_policy ? 'detach_mode' then
+    v_detach_mode := lower(trim(coalesce(v_policy->>'detach_mode', '')));
+  end if;
+
+  if v_policy ? 'detach_min_age' then
+    v_detach_min_age := (v_policy->>'detach_min_age')::interval;
+  end if;
+
+  if v_partition_lookahead < interval '0 seconds' then
+    raise exception 'partition_lookahead must be non-negative';
+  end if;
+
+  if v_partition_lookback < interval '0 seconds' then
+    raise exception 'partition_lookback must be non-negative';
+  end if;
+
+  if v_cleanup_ttl_seconds < 0 then
+    raise exception 'cleanup_ttl_seconds must be non-negative';
+  end if;
+
+  if v_cleanup_limit < 1 then
+    raise exception 'cleanup_limit must be at least 1';
+  end if;
+
+  if v_detach_mode not in ('none', 'empty') then
+    raise exception 'Unsupported detach mode "%"', v_detach_mode;
+  end if;
+
+  if v_detach_min_age < interval '0 seconds' then
+    raise exception 'detach_min_age must be non-negative';
+  end if;
+
+  update absurd.queues
+     set partition_lookahead = v_partition_lookahead,
+         partition_lookback = v_partition_lookback,
+         cleanup_ttl_seconds = v_cleanup_ttl_seconds,
+         cleanup_limit = v_cleanup_limit,
+         detach_mode = v_detach_mode,
+         detach_min_age = v_detach_min_age
+   where queue_name = p_queue_name;
+end;
 $$;
 
 -- Returns the current state and terminal payload (if any) for a task.
@@ -1727,6 +1907,58 @@ begin
 end;
 $$;
 
+-- Runs one cleanup batch for all queues (or one specific queue), using
+-- per-queue policy stored in absurd.queues.
+create function absurd.cleanup_all_queues (
+  p_queue_name text default null
+)
+  returns table (
+    queue_name text,
+    tasks_deleted integer,
+    events_deleted integer
+  )
+  language plpgsql
+as $$
+declare
+  v_queue record;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  for v_queue in
+    select
+      q.queue_name,
+      q.cleanup_ttl_seconds,
+      q.cleanup_limit
+    from absurd.queues q
+    where p_queue_name is null or q.queue_name = p_queue_name
+    order by q.queue_name
+  loop
+    queue_name := v_queue.queue_name;
+    tasks_deleted := absurd.cleanup_tasks(
+      v_queue.queue_name,
+      v_queue.cleanup_ttl_seconds,
+      v_queue.cleanup_limit
+    );
+    events_deleted := absurd.cleanup_events(
+      v_queue.queue_name,
+      v_queue.cleanup_ttl_seconds,
+      v_queue.cleanup_limit
+    );
+    return next;
+  end loop;
+end;
+$$;
+
 -- Cleans up old completed, failed, or cancelled tasks and their related data.
 -- Deletes tasks whose terminal timestamp (completed_at, failed_at, or cancelled_at)
 -- is older than the specified TTL in seconds.
@@ -2041,23 +2273,17 @@ $$;
 
 -- Ensures weekly UUIDv7 partitions exist for partitioned queues.
 --
--- By default this creates partitions for:
--- * the week containing now()
--- * the previous week if now() is within 1 day of a week boundary
---
--- p_until can be provided to pre-create partitions up to a future timestamp.
+-- Window selection is queue-policy driven:
+-- * start = week_bucket_utc(now() - partition_lookback)
+-- * end   = week_bucket_utc(now() + partition_lookahead)
 create function absurd.ensure_partitions (
-  p_queue_name text default null,
-  p_until timestamptz default null,
-  p_clock_skew interval default interval '1 day'
+  p_queue_name text default null
 )
   returns void
   language plpgsql
 as $$
 declare
   v_now timestamptz := absurd.current_time();
-  v_until timestamptz := coalesce(p_until, absurd.current_time());
-  v_skew interval := coalesce(p_clock_skew, interval '1 day');
   v_window_start timestamptz;
   v_window_end timestamptz;
   v_week_start timestamptz;
@@ -2067,36 +2293,31 @@ declare
   v_uuid_to uuid;
   v_queue record;
 begin
-  if v_skew < interval '0 seconds' then
-    raise exception 'clock skew tolerance must be non-negative';
-  end if;
-
   if p_queue_name is not null then
     p_queue_name := absurd.validate_queue_name(p_queue_name);
 
     if not exists (
       select 1
-      from absurd.queues
-      where queue_name = p_queue_name
+      from absurd.queues q
+      where q.queue_name = p_queue_name
     ) then
       raise exception 'Queue "%" does not exist', p_queue_name;
     end if;
   end if;
 
-  if v_until < v_now then
-    v_until := v_now;
-  end if;
-
-  v_window_start := absurd.week_bucket_utc(v_now - v_skew);
-  v_window_end := absurd.week_bucket_utc(v_until);
-
   for v_queue in
-    select queue_name
+    select
+      queue_name,
+      partition_lookahead,
+      partition_lookback
     from absurd.queues
     where storage_mode = 'partitioned'
       and (p_queue_name is null or queue_name = p_queue_name)
     order by queue_name
   loop
+    v_window_start := absurd.week_bucket_utc(v_now - v_queue.partition_lookback);
+    v_window_end := absurd.week_bucket_utc(v_now + v_queue.partition_lookahead);
+
     execute format(
       'create table if not exists absurd.%I partition of absurd.%I default',
       't_' || v_queue.queue_name || '_d',
@@ -2160,6 +2381,579 @@ begin
 
       v_week_start := v_week_end;
     end loop;
+  end loop;
+end;
+$$;
+
+-- Lists detach/drop commands for eligible partition tables.
+--
+-- This does not execute detach directly because
+-- DETACH PARTITION ... CONCURRENTLY must run as top-level SQL.
+-- Use this output from an external scheduler/executor.
+create function absurd.list_detach_candidates (
+  p_queue_name text default null
+)
+  returns table (
+    queue_name text,
+    parent_table text,
+    partition_table text,
+    candidate_hash text,
+    detach_sql text,
+    drop_sql text
+  )
+  language plpgsql
+as $$
+declare
+  v_now timestamptz := absurd.current_time();
+  v_queue record;
+  v_parent_prefix text;
+  v_parent_table text;
+  v_parent_oid oid;
+  v_part record;
+  v_upper_uuid uuid;
+  v_upper_ts timestamptz;
+  v_has_rows boolean;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    if not exists (
+      select 1
+      from absurd.queues q
+      where q.queue_name = p_queue_name
+    ) then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  for v_queue in
+    select
+      q.queue_name,
+      q.detach_mode,
+      q.detach_min_age
+    from absurd.queues q
+    where q.storage_mode = 'partitioned'
+      and q.detach_mode = 'empty'
+      and (p_queue_name is null or q.queue_name = p_queue_name)
+    order by q.queue_name
+  loop
+    foreach v_parent_prefix in array array['t', 'r', 'c', 'w'] loop
+      v_parent_table := v_parent_prefix || '_' || v_queue.queue_name;
+
+      select c.oid
+        into v_parent_oid
+        from pg_class c
+        join pg_namespace n on n.oid = c.relnamespace
+       where n.nspname = 'absurd'
+         and c.relname = v_parent_table;
+
+      if v_parent_oid is null then
+        continue;
+      end if;
+
+      for v_part in
+        select
+          child.relname as partition_name,
+          pg_get_expr(child.relpartbound, child.oid) as part_bound
+        from pg_inherits inh
+        join pg_class child on child.oid = inh.inhrelid
+        where inh.inhparent = v_parent_oid
+      loop
+        if v_part.part_bound = 'DEFAULT' then
+          continue;
+        end if;
+
+        select
+          (regexp_match(v_part.part_bound, 'TO \(''([^'']+)''(::uuid)?\)'))[1]::uuid
+          into v_upper_uuid;
+
+        if v_upper_uuid is null then
+          continue;
+        end if;
+
+        v_upper_ts := absurd.uuidv7_timestamp(v_upper_uuid);
+
+        if v_upper_ts is null then
+          continue;
+        end if;
+
+        if v_upper_ts >= (v_now - v_queue.detach_min_age) then
+          continue;
+        end if;
+
+        execute format(
+          'select exists (select 1 from absurd.%I limit 1)',
+          v_part.partition_name
+        )
+        into v_has_rows;
+
+        if coalesce(v_has_rows, false) then
+          continue;
+        end if;
+
+        queue_name := v_queue.queue_name;
+        parent_table := v_parent_table;
+        partition_table := v_part.partition_name;
+        candidate_hash := substr(md5(v_parent_table || ':' || v_part.partition_name), 1, 12);
+        detach_sql := format(
+          'alter table absurd.%I detach partition absurd.%I concurrently',
+          v_parent_table,
+          v_part.partition_name
+        );
+        drop_sql := format(
+          'drop table if exists absurd.%I',
+          v_part.partition_name
+        );
+
+        return next;
+      end loop;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- Drops a detached partition table if it is no longer attached.
+--
+-- Returns true when the table was dropped. If p_unschedule_job_name is
+-- provided and pg_cron is available, the matching cron job is unscheduled
+-- once the partition is gone.
+create function absurd.drop_detached_partition (
+  p_partition_table text,
+  p_unschedule_job_name text default null
+)
+  returns boolean
+  language plpgsql
+as $$
+declare
+  v_partition_table text := nullif(trim(coalesce(p_partition_table, '')), '');
+  v_partition_oid oid;
+  v_is_attached boolean := false;
+  v_detach_job_name text;
+begin
+  if p_unschedule_job_name like 'absurd_drop_run_%' then
+    v_detach_job_name :=
+      'absurd_detach_run_' || substr(p_unschedule_job_name, length('absurd_drop_run_') + 1);
+  end if;
+
+  if v_partition_table is null then
+    raise exception 'partition table must be provided';
+  end if;
+
+  select c.oid
+    into v_partition_oid
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'absurd'
+     and c.relname = v_partition_table;
+
+  if v_partition_oid is null then
+    if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
+      perform cron.unschedule(jobid)
+        from cron.job
+       where jobname in (p_unschedule_job_name, coalesce(v_detach_job_name, ''));
+    end if;
+    return false;
+  end if;
+
+  select exists (
+    select 1
+    from pg_inherits
+    where inhrelid = v_partition_oid
+  )
+  into v_is_attached;
+
+  if v_is_attached then
+    return false;
+  end if;
+
+  execute format('drop table if exists absurd.%I', v_partition_table);
+
+  if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
+    perform cron.unschedule(jobid)
+      from cron.job
+     where jobname in (p_unschedule_job_name, coalesce(v_detach_job_name, ''));
+  end if;
+
+  return true;
+end;
+$$;
+
+-- Ensures per-partition one-off-ish cron jobs exist for detach/drop.
+--
+-- Detach jobs run the raw top-level DETACH ... CONCURRENTLY statement and
+-- unschedule themselves after success. If detach fails due transient locking,
+-- the job keeps retrying on the configured schedule.
+--
+-- Drop jobs poll via absurd.drop_detached_partition() and unschedule
+-- themselves once the partition has been dropped.
+create function absurd.ensure_detach_jobs (
+  p_queue_name text default null,
+  p_scope text default null,
+  p_job_schedule text default '* * * * *'
+)
+  returns table (
+    job_name text,
+    job_id bigint,
+    queue_name text,
+    partition_table text,
+    job_kind text
+  )
+  language plpgsql
+as $$
+declare
+  v_scope text;
+  v_candidate record;
+  v_detach_job_name text;
+  v_drop_job_name text;
+  v_detach_command text;
+  v_drop_command text;
+  v_job_id bigint;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+  end if;
+
+  if p_job_schedule is null or length(trim(p_job_schedule)) = 0 then
+    raise exception 'Detach job schedule must be provided';
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_scope := lower(trim(coalesce(p_scope, '')));
+  if v_scope = '' then
+    v_scope := case
+      when p_queue_name is null then 'all'
+      else substr(md5(p_queue_name), 1, 12)
+    end;
+  end if;
+
+  if v_scope !~ '^[a-z0-9_]+$' then
+    raise exception 'Invalid detach job scope "%"', v_scope;
+  end if;
+
+  for v_candidate in
+    select c.*
+    from absurd.list_detach_candidates(p_queue_name) c
+    order by c.queue_name, c.parent_table, c.partition_table
+  loop
+    v_detach_job_name := format(
+      'absurd_detach_run_%s_%s',
+      v_scope,
+      v_candidate.candidate_hash
+    );
+    v_drop_job_name := format(
+      'absurd_drop_run_%s_%s',
+      v_scope,
+      v_candidate.candidate_hash
+    );
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = v_detach_job_name
+         or jobname like ('absurd_detach_run_%_' || v_candidate.candidate_hash)
+    ) then
+      v_detach_command := format(
+        '%s; select cron.unschedule(jobid) from cron.job where jobname = %L;',
+        v_candidate.detach_sql,
+        v_detach_job_name
+      );
+
+      execute 'select cron.schedule($1, $2, $3)'
+        into v_job_id
+        using v_detach_job_name, p_job_schedule, v_detach_command;
+
+      job_name := v_detach_job_name;
+      job_id := v_job_id;
+      queue_name := v_candidate.queue_name;
+      partition_table := v_candidate.partition_table;
+      job_kind := 'detach';
+      return next;
+    end if;
+
+    if not exists (
+      select 1
+      from cron.job
+      where jobname = v_drop_job_name
+         or jobname like ('absurd_drop_run_%_' || v_candidate.candidate_hash)
+    ) then
+      v_drop_command := format(
+        'select absurd.drop_detached_partition(%L, %L);',
+        v_candidate.partition_table,
+        v_drop_job_name
+      );
+
+      execute 'select cron.schedule($1, $2, $3)'
+        into v_job_id
+        using v_drop_job_name, p_job_schedule, v_drop_command;
+
+      job_name := v_drop_job_name;
+      job_id := v_job_id;
+      queue_name := v_candidate.queue_name;
+      partition_table := v_candidate.partition_table;
+      job_kind := 'drop';
+      return next;
+    end if;
+  end loop;
+end;
+$$;
+
+-- Configures pg_cron jobs for partition provisioning, cleanup, and detach planning.
+--
+-- Detach planning schedules per-partition jobs (via absurd.ensure_detach_jobs)
+-- that run raw DETACH ... CONCURRENTLY and follow-up drop checks.
+--
+-- Requires pg_cron to be installed (or compatible cron schema/functions).
+create function absurd.enable_cron (
+  p_queue_name text default null,
+  p_partition_schedule text default '5 * * * *',
+  p_cleanup_schedule text default '17 * * * *',
+  p_detach_schedule text default '29 * * * *'
+)
+  returns table (
+    job_name text,
+    job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_queue_exists boolean := false;
+  v_queue_literal text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_partition_command text;
+  v_cleanup_command text;
+  v_detach_plan_command text;
+  v_partitions_job_id bigint;
+  v_cleanup_job_id bigint;
+  v_detach_plan_job_id bigint;
+  v_existing_job_id bigint;
+  v_job_suffix text;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+    select exists (
+      select 1
+      from absurd.queues
+      where queue_name = p_queue_name
+    )
+    into v_queue_exists;
+
+    if not v_queue_exists then
+      raise exception 'Queue "%" does not exist', p_queue_name;
+    end if;
+  end if;
+
+  if p_partition_schedule is null or length(trim(p_partition_schedule)) = 0 then
+    raise exception 'Partition schedule must be provided';
+  end if;
+
+  if p_cleanup_schedule is null or length(trim(p_cleanup_schedule)) = 0 then
+    raise exception 'Cleanup schedule must be provided';
+  end if;
+
+  if p_detach_schedule is null or length(trim(p_detach_schedule)) = 0 then
+    raise exception 'Detach schedule must be provided';
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_queue_literal := case
+    when p_queue_name is null then 'null::text'
+    else quote_literal(p_queue_name)
+  end;
+
+  v_partition_command := format(
+    'select absurd.ensure_partitions(%s);',
+    v_queue_literal
+  );
+
+  v_cleanup_command := format(
+    'select * from absurd.cleanup_all_queues(%s);',
+    v_queue_literal
+  );
+
+  v_job_suffix := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+  end;
+
+  v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+  v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+  v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+
+  v_detach_plan_command := format(
+    'select * from absurd.ensure_detach_jobs(%s, %L);',
+    v_queue_literal,
+    v_job_suffix
+  );
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_partition_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_cleanup_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_detach_plan_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_partitions_job_id
+    using v_partition_job_name, p_partition_schedule, v_partition_command;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_cleanup_job_id
+    using v_cleanup_job_name, p_cleanup_schedule, v_cleanup_command;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_detach_plan_job_id
+    using v_detach_plan_job_name, p_detach_schedule, v_detach_plan_command;
+
+  job_name := v_partition_job_name;
+  job_id := v_partitions_job_id;
+  return next;
+
+  job_name := v_cleanup_job_name;
+  job_id := v_cleanup_job_id;
+  return next;
+
+  job_name := v_detach_plan_job_name;
+  job_id := v_detach_plan_job_id;
+  return next;
+end;
+$$;
+
+-- Removes pg_cron jobs previously installed by absurd.enable_cron.
+--
+-- If p_queue_name is null, this removes the global ('all') maintenance jobs
+-- and global-scope detach/drop run jobs.
+-- If p_queue_name is provided, this removes jobs for that specific queue scope,
+-- including detach/drop run jobs.
+create function absurd.disable_cron (
+  p_queue_name text default null
+)
+  returns table (
+    job_name text,
+    job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_job_suffix text;
+  v_partition_job_name text;
+  v_cleanup_job_name text;
+  v_detach_plan_job_name text;
+  v_detach_run_pattern text;
+  v_drop_run_pattern text;
+  v_existing_job record;
+begin
+  if p_queue_name is not null then
+    p_queue_name := absurd.validate_queue_name(p_queue_name);
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_job_suffix := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+  end;
+
+  v_partition_job_name := 'absurd_partitions_' || v_job_suffix;
+  v_cleanup_job_name := 'absurd_cleanup_' || v_job_suffix;
+  v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
+  v_detach_run_pattern := 'absurd_detach_run_' || v_job_suffix || '_%';
+  v_drop_run_pattern := 'absurd_drop_run_' || v_job_suffix || '_%';
+
+  for v_existing_job in
+    execute 'select jobid, jobname
+               from cron.job
+              where jobname = $1
+                 or jobname = $2
+                 or jobname = $3
+                 or jobname like $4
+                 or jobname like $5
+              order by jobname, jobid'
+    using v_partition_job_name,
+          v_cleanup_job_name,
+          v_detach_plan_job_name,
+          v_detach_run_pattern,
+          v_drop_run_pattern
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job.jobid;
+
+    job_name := v_existing_job.jobname;
+    job_id := v_existing_job.jobid;
+    return next;
   end loop;
 end;
 $$;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -2404,8 +2404,7 @@ $$;
 
 -- Lists detach/drop commands for eligible partition tables.
 --
--- This does not execute detach directly because
--- DETACH PARTITION ... CONCURRENTLY must run as top-level SQL.
+-- This does not execute detach directly.
 -- Use this output from an external scheduler/executor.
 create function absurd.list_detach_candidates (
   p_queue_name text default null
@@ -2511,7 +2510,7 @@ begin
         parent_table := v_parent_table;
         partition_table := v_part.partition_name;
         detach_sql := format(
-          'alter table absurd.%I detach partition absurd.%I concurrently',
+          'alter table absurd.%I detach partition absurd.%I',
           v_parent_table,
           v_part.partition_name
         );
@@ -2531,7 +2530,9 @@ $$;
 --
 -- Returns true when the table was dropped. If p_unschedule_job_name is
 -- provided and pg_cron is available, the matching cron job is unscheduled
--- once the partition is gone.
+-- once the partition is gone. The paired detach job (if derivable from
+-- p_unschedule_job_name) is unscheduled as soon as the partition is observed
+-- detached so DETACH does not keep retrying.
 create function absurd.drop_detached_partition (
   p_partition_table text,
   p_unschedule_job_name text default null
@@ -2581,12 +2582,20 @@ begin
     return false;
   end if;
 
+  -- Once detached, stop retrying detach runs immediately. Keep drop
+  -- scheduled until the table is actually dropped.
+  if v_detach_job_name is not null and to_regclass('cron.job') is not null then
+    perform cron.unschedule(jobid)
+      from cron.job
+     where jobname = v_detach_job_name;
+  end if;
+
   execute format('drop table if exists absurd.%I', v_partition_table);
 
   if p_unschedule_job_name is not null and to_regclass('cron.job') is not null then
     perform cron.unschedule(jobid)
       from cron.job
-     where jobname in (p_unschedule_job_name, coalesce(v_detach_job_name, ''));
+     where jobname = p_unschedule_job_name;
   end if;
 
   return true;
@@ -2595,12 +2604,11 @@ $$;
 
 -- Schedules per-partition one-off-ish cron jobs for detach/drop.
 --
--- Detach jobs run the raw top-level DETACH ... CONCURRENTLY statement and
--- unschedule themselves after success. If detach fails due transient locking,
--- the job keeps retrying every minute.
+-- Detach jobs run the raw DETACH PARTITION statement.
 --
--- Drop jobs poll via absurd.drop_detached_partition() and unschedule
--- themselves once the partition has been dropped.
+-- Drop jobs poll via absurd.drop_detached_partition(); once a partition is
+-- detached, that function unschedules the paired detach job immediately and
+-- keeps retrying drop until the table is gone.
 create function absurd.schedule_detach_jobs (
   p_queue_name text default null
 )
@@ -2684,11 +2692,7 @@ begin
       where jobname = v_detach_job_name
          or jobname like ('absurd_detach_run_%_' || v_candidate_key)
     ) then
-      v_detach_command := format(
-        '%s; select cron.unschedule(jobid) from cron.job where jobname = %L;',
-        v_candidate.detach_sql,
-        v_detach_job_name
-      );
+      v_detach_command := v_candidate.detach_sql;
 
       execute 'select cron.schedule($1, $2, $3)'
         into v_job_id
@@ -2732,7 +2736,7 @@ $$;
 -- Configures pg_cron jobs for partition provisioning, cleanup, and detach planning.
 --
 -- Detach planning schedules per-partition jobs (via absurd.schedule_detach_jobs)
--- that run raw DETACH ... CONCURRENTLY and follow-up drop checks.
+-- that run raw DETACH statements and follow-up drop checks.
 --
 -- Requires pg_cron to be installed (or compatible cron schema/functions).
 create function absurd.enable_cron (

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -703,25 +703,25 @@ begin
 
       if v_row_count = 0 then
         execute format(
-          'select task_id
-             from absurd.%I
-            where idempotency_key = $1',
-          'i_' || p_queue_name
-        )
-        into v_existing_task_id
-        using v_idempotency_key;
-
-        execute format(
-          'select last_attempt_run, attempts
-             from absurd.%I
-            where task_id = $1',
+          'select i.task_id, t.last_attempt_run, t.attempts
+             from absurd.%I i
+             join absurd.%I t on t.task_id = i.task_id
+            where i.idempotency_key = $1
+              for key share of i',
+          'i_' || p_queue_name,
           't_' || p_queue_name
         )
-        into v_existing_run_id, v_existing_attempt
-        using v_existing_task_id;
+        into v_existing_task_id, v_existing_run_id, v_existing_attempt
+        using v_idempotency_key;
 
-        if v_existing_task_id is null or v_existing_run_id is null then
-          raise exception 'Idempotency key "%" is inconsistent in queue "%"', v_idempotency_key, p_queue_name;
+        if v_existing_task_id is null then
+          raise exception 'Idempotency key "%" in queue "%" was concurrently cleaned up', v_idempotency_key, p_queue_name
+            using errcode = '40001',
+                  hint = 'Retry spawn_task with the same idempotency key.';
+        end if;
+
+        if v_existing_run_id is null then
+          raise exception 'Idempotency key "%" in queue "%" resolved to task "%" without a run', v_idempotency_key, p_queue_name, v_existing_task_id;
         end if;
 
         return query select v_existing_task_id, v_existing_run_id, v_existing_attempt, false;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -58,6 +58,8 @@ create table if not exists absurd.queues (
   created_at timestamptz not null default absurd.current_time(),
   storage_mode text not null default 'unpartitioned'
     check (storage_mode in ('unpartitioned', 'partitioned')),
+  default_partition text not null default 'enabled'
+    check (default_partition in ('enabled', 'disabled')),
   partition_lookahead interval not null default interval '28 days'
     check (partition_lookahead >= interval '0 seconds'),
   partition_lookback interval not null default interval '1 day'
@@ -440,6 +442,7 @@ create function absurd.get_queue_policy (
   returns table (
     queue_name text,
     storage_mode text,
+    default_partition text,
     partition_lookahead interval,
     partition_lookback interval,
     cleanup_ttl interval,
@@ -452,6 +455,7 @@ as $$
   select
     q.queue_name,
     q.storage_mode,
+    q.default_partition,
     q.partition_lookahead,
     q.partition_lookback,
     q.cleanup_ttl,
@@ -471,6 +475,7 @@ $$;
 -- * cleanup_limit (integer >= 1)
 -- * detach_mode ('none' | 'empty')
 -- * detach_min_age (interval text)
+-- * default_partition ('enabled' | 'disabled')
 create function absurd.set_queue_policy (
   p_queue_name text,
   p_policy jsonb
@@ -482,6 +487,14 @@ declare
   v_policy jsonb := coalesce(p_policy, '{}'::jsonb);
   v_unknown_key text;
   v_exists boolean := false;
+  v_storage_mode text;
+  v_default_partition text;
+  v_previous_default_partition text;
+  v_parent_prefix text;
+  v_parent_table text;
+  v_default_table text;
+  v_default_attached boolean;
+  v_default_has_rows boolean;
 
   v_partition_lookahead interval;
   v_partition_lookback interval;
@@ -505,7 +518,8 @@ begin
       'cleanup_ttl',
       'cleanup_limit',
       'detach_mode',
-      'detach_min_age'
+      'detach_min_age',
+      'default_partition'
    )
    limit 1;
 
@@ -525,6 +539,8 @@ begin
   end if;
 
   select
+    storage_mode,
+    default_partition,
     partition_lookahead,
     partition_lookback,
     cleanup_ttl,
@@ -532,6 +548,8 @@ begin
     detach_mode,
     detach_min_age
   into
+    v_storage_mode,
+    v_default_partition,
     v_partition_lookahead,
     v_partition_lookback,
     v_cleanup_ttl,
@@ -566,6 +584,12 @@ begin
     v_detach_min_age := (v_policy->>'detach_min_age')::interval;
   end if;
 
+  v_previous_default_partition := v_default_partition;
+
+  if v_policy ? 'default_partition' then
+    v_default_partition := lower(trim(coalesce(v_policy->>'default_partition', '')));
+  end if;
+
   if v_partition_lookahead < interval '0 seconds' then
     raise exception 'partition_lookahead must be non-negative';
   end if;
@@ -590,14 +614,78 @@ begin
     raise exception 'detach_min_age must be non-negative';
   end if;
 
+  if v_default_partition not in ('enabled', 'disabled') then
+    raise exception 'Unsupported default_partition mode "%"', v_default_partition;
+  end if;
+
+  if v_storage_mode <> 'partitioned' and v_policy ? 'default_partition' then
+    raise exception 'default_partition policy is only supported for partitioned queues';
+  end if;
+
   update absurd.queues
-     set partition_lookahead = v_partition_lookahead,
+     set default_partition = v_default_partition,
+         partition_lookahead = v_partition_lookahead,
          partition_lookback = v_partition_lookback,
          cleanup_ttl = v_cleanup_ttl,
          cleanup_limit = v_cleanup_limit,
          detach_mode = v_detach_mode,
          detach_min_age = v_detach_min_age
    where queue_name = p_queue_name;
+
+  if v_storage_mode = 'partitioned'
+     and v_previous_default_partition <> v_default_partition then
+    if v_default_partition = 'enabled' then
+      perform absurd.ensure_partitions(p_queue_name);
+    else
+      foreach v_parent_prefix in array array['t', 'r', 'c', 'w'] loop
+        v_parent_table := v_parent_prefix || '_' || p_queue_name;
+        v_default_table := v_parent_table || '_d';
+
+        select exists (
+          select 1
+          from pg_inherits inh
+          join pg_class parent on parent.oid = inh.inhparent
+          join pg_class child on child.oid = inh.inhrelid
+          join pg_namespace n on n.oid = parent.relnamespace
+          where n.nspname = 'absurd'
+            and parent.relname = v_parent_table
+            and child.relname = v_default_table
+        )
+        into v_default_attached;
+
+        if not coalesce(v_default_attached, false) then
+          continue;
+        end if;
+
+        -- Block out-of-window writes into the default partition while we
+        -- validate emptiness and detach/drop it.
+        execute format(
+          'lock table absurd.%I in access exclusive mode',
+          v_default_table
+        );
+
+        execute format(
+          'select exists (select 1 from absurd.%I limit 1)',
+          v_default_table
+        )
+        into v_default_has_rows;
+
+        if coalesce(v_default_has_rows, false) then
+          raise exception
+            'Cannot disable default_partition for queue "%": default partition "%" is not empty',
+            p_queue_name,
+            v_default_table;
+        end if;
+
+        execute format(
+          'alter table absurd.%I detach partition absurd.%I',
+          v_parent_table,
+          v_default_table
+        );
+        execute format('drop table if exists absurd.%I', v_default_table);
+      end loop;
+    end if;
+  end if;
 end;
 $$;
 
@@ -2325,6 +2413,7 @@ begin
   for v_queue in
     select
       queue_name,
+      default_partition,
       partition_lookahead,
       partition_lookback
     from absurd.queues
@@ -2335,26 +2424,28 @@ begin
     v_window_start := absurd.week_bucket_utc(v_now - v_queue.partition_lookback);
     v_window_end := absurd.week_bucket_utc(v_now + v_queue.partition_lookahead);
 
-    execute format(
-      'create table if not exists absurd.%I partition of absurd.%I default',
-      't_' || v_queue.queue_name || '_d',
-      't_' || v_queue.queue_name
-    );
-    execute format(
-      'create table if not exists absurd.%I partition of absurd.%I default',
-      'r_' || v_queue.queue_name || '_d',
-      'r_' || v_queue.queue_name
-    );
-    execute format(
-      'create table if not exists absurd.%I partition of absurd.%I default',
-      'c_' || v_queue.queue_name || '_d',
-      'c_' || v_queue.queue_name
-    );
-    execute format(
-      'create table if not exists absurd.%I partition of absurd.%I default',
-      'w_' || v_queue.queue_name || '_d',
-      'w_' || v_queue.queue_name
-    );
+    if v_queue.default_partition = 'enabled' then
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        't_' || v_queue.queue_name || '_d',
+        't_' || v_queue.queue_name
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        'r_' || v_queue.queue_name || '_d',
+        'r_' || v_queue.queue_name
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        'c_' || v_queue.queue_name || '_d',
+        'c_' || v_queue.queue_name
+      );
+      execute format(
+        'create table if not exists absurd.%I partition of absurd.%I default',
+        'w_' || v_queue.queue_name || '_d',
+        'w_' || v_queue.queue_name
+      );
+    end if;
 
     v_week_start := v_window_start;
     while v_week_start <= v_window_end loop
@@ -2424,6 +2515,7 @@ declare
   v_parent_prefix text;
   v_parent_table text;
   v_parent_oid oid;
+  v_parent_has_default_partition boolean;
   v_part record;
   v_upper_uuid uuid;
   v_upper_ts timestamptz;
@@ -2465,6 +2557,15 @@ begin
       if v_parent_oid is null then
         continue;
       end if;
+
+      select exists (
+        select 1
+        from pg_inherits inh
+        join pg_class child on child.oid = inh.inhrelid
+        where inh.inhparent = v_parent_oid
+          and pg_get_expr(child.relpartbound, child.oid) = 'DEFAULT'
+      )
+      into v_parent_has_default_partition;
 
       for v_part in
         select
@@ -2509,11 +2610,19 @@ begin
         queue_name := v_queue.queue_name;
         parent_table := v_parent_table;
         partition_table := v_part.partition_name;
-        detach_sql := format(
-          'alter table absurd.%I detach partition absurd.%I',
-          v_parent_table,
-          v_part.partition_name
-        );
+        if coalesce(v_parent_has_default_partition, false) then
+          detach_sql := format(
+            'alter table absurd.%I detach partition absurd.%I',
+            v_parent_table,
+            v_part.partition_name
+          );
+        else
+          detach_sql := format(
+            'alter table absurd.%I detach partition absurd.%I concurrently',
+            v_parent_table,
+            v_part.partition_name
+          );
+        end if;
         drop_sql := format(
           'drop table if exists absurd.%I',
           v_part.partition_name
@@ -2602,9 +2711,14 @@ begin
 end;
 $$;
 
--- Schedules per-partition one-off-ish cron jobs for detach/drop.
+-- Schedules per-parent one-at-a-time cron jobs for detach/drop.
 --
--- Detach jobs run the raw DETACH PARTITION statement.
+-- For each parent table, only the oldest eligible partition is scheduled and
+-- only when there is no active detach/drop job for that parent.
+--
+-- Detach jobs run the raw DETACH statement. They use CONCURRENTLY when
+-- possible; if a parent still has an attached DEFAULT partition, they fall
+-- back to non-concurrent DETACH (Postgres limitation).
 --
 -- Drop jobs poll via absurd.drop_detached_partition(); once a partition is
 -- detached, that function unschedules the paired detach job immediately and
@@ -2624,11 +2738,13 @@ as $$
 declare
   v_scope text;
   v_candidate record;
+  v_parent_key text;
   v_candidate_key text;
   v_detach_job_name text;
   v_drop_job_name text;
   v_detach_command text;
   v_drop_command text;
+  v_parent_has_default_partition boolean;
   v_job_id bigint;
 begin
   if p_queue_name is not null then
@@ -2665,10 +2781,51 @@ begin
   end;
 
   for v_candidate in
-    select c.*
-    from absurd.list_detach_candidates(p_queue_name) c
-    order by c.queue_name, c.parent_table, c.partition_table
+    with candidates as (
+      select
+        c.*,
+        absurd.uuidv7_timestamp(
+          (regexp_match(
+            pg_get_expr(child.relpartbound, child.oid),
+            'TO \(''([^'']+)''(::uuid)?\)'
+          ))[1]::uuid
+        ) as upper_ts
+      from absurd.list_detach_candidates(p_queue_name) c
+      join pg_class child on child.relname = c.partition_table
+      join pg_namespace n on n.oid = child.relnamespace
+      where n.nspname = 'absurd'
+    ),
+    ranked as (
+      select
+        candidates.*,
+        row_number() over (
+          partition by candidates.parent_table
+          order by candidates.upper_ts asc nulls last, candidates.partition_table asc
+        ) as rn
+      from candidates
+    )
+    select
+      ranked.queue_name,
+      ranked.parent_table,
+      ranked.partition_table,
+      ranked.detach_sql,
+      ranked.drop_sql
+    from ranked
+    where ranked.rn = 1
+    order by ranked.queue_name, ranked.parent_table, ranked.partition_table
   loop
+    v_parent_key := substr(md5(v_candidate.parent_table), 1, 8);
+
+    -- Only one active detach pipeline per parent table.
+    if exists (
+      select 1
+      from cron.job
+      where jobname like ('absurd_detach_run_%_' || v_parent_key || '_%')
+         or jobname like ('absurd_drop_run_%_' || v_parent_key || '_%')
+    ) then
+      continue;
+    end if;
+
     v_candidate_key := substr(
       md5(v_candidate.parent_table || ':' || v_candidate.partition_table),
       1,
@@ -2676,13 +2833,15 @@ begin
     );
 
     v_detach_job_name := format(
-      'absurd_detach_run_%s_%s',
+      'absurd_detach_run_%s_%s_%s',
       v_scope,
+      v_parent_key,
       v_candidate_key
     );
     v_drop_job_name := format(
-      'absurd_drop_run_%s_%s',
+      'absurd_drop_run_%s_%s_%s',
       v_scope,
+      v_parent_key,
       v_candidate_key
     );
 
@@ -2692,7 +2851,28 @@ begin
       where jobname = v_detach_job_name
          or jobname like ('absurd_detach_run_%_' || v_candidate_key)
     ) then
-      v_detach_command := v_candidate.detach_sql;
+      select exists (
+        select 1
+        from pg_class parent
+        join pg_namespace pn on pn.oid = parent.relnamespace
+        join pg_inherits inh on inh.inhparent = parent.oid
+        join pg_class child on child.oid = inh.inhrelid
+        where pn.nspname = 'absurd'
+          and parent.relname = v_candidate.parent_table
+          and pg_get_expr(child.relpartbound, child.oid) = 'DEFAULT'
+      )
+      into v_parent_has_default_partition;
+
+      if coalesce(v_parent_has_default_partition, false) then
+        v_detach_command := regexp_replace(
+          v_candidate.detach_sql,
+          ' concurrently$',
+          '',
+          'i'
+        );
+      else
+        v_detach_command := v_candidate.detach_sql;
+      end if;
 
       execute 'select cron.schedule($1, $2, $3)'
         into v_job_id

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -92,7 +92,7 @@ create function absurd.validate_queue_name (p_queue_name text)
   language plpgsql
 as $$
 begin
-  if p_queue_name is null or length(trim(p_queue_name)) = 0 then
+  if p_queue_name is null or p_queue_name = '' then
     raise exception 'Queue name must be provided';
   end if;
 
@@ -2582,18 +2582,16 @@ begin
 end;
 $$;
 
--- Ensures per-partition one-off-ish cron jobs exist for detach/drop.
+-- Schedules per-partition one-off-ish cron jobs for detach/drop.
 --
 -- Detach jobs run the raw top-level DETACH ... CONCURRENTLY statement and
 -- unschedule themselves after success. If detach fails due transient locking,
--- the job keeps retrying on the configured schedule.
+-- the job keeps retrying every minute.
 --
 -- Drop jobs poll via absurd.drop_detached_partition() and unschedule
 -- themselves once the partition has been dropped.
-create function absurd.ensure_detach_jobs (
-  p_queue_name text default null,
-  p_scope text default null,
-  p_job_schedule text default '* * * * *'
+create function absurd.schedule_detach_jobs (
+  p_queue_name text default null
 )
   returns table (
     job_name text,
@@ -2616,10 +2614,6 @@ declare
 begin
   if p_queue_name is not null then
     p_queue_name := absurd.validate_queue_name(p_queue_name);
-  end if;
-
-  if p_job_schedule is null or length(trim(p_job_schedule)) = 0 then
-    raise exception 'Detach job schedule must be provided';
   end if;
 
   if to_regclass('cron.job') is null then
@@ -2646,17 +2640,10 @@ begin
     raise exception 'pg_cron is not available (missing cron.unschedule)';
   end if;
 
-  v_scope := lower(trim(coalesce(p_scope, '')));
-  if v_scope = '' then
-    v_scope := case
-      when p_queue_name is null then 'all'
-      else substr(md5(p_queue_name), 1, 12)
-    end;
-  end if;
-
-  if v_scope !~ '^[a-z0-9_]+$' then
-    raise exception 'Invalid detach job scope "%"', v_scope;
-  end if;
+  v_scope := case
+    when p_queue_name is null then 'all'
+    else substr(md5(p_queue_name), 1, 12)
+  end;
 
   for v_candidate in
     select c.*
@@ -2694,7 +2681,7 @@ begin
 
       execute 'select cron.schedule($1, $2, $3)'
         into v_job_id
-        using v_detach_job_name, p_job_schedule, v_detach_command;
+        using v_detach_job_name, '* * * * *', v_detach_command;
 
       job_name := v_detach_job_name;
       job_id := v_job_id;
@@ -2718,7 +2705,7 @@ begin
 
       execute 'select cron.schedule($1, $2, $3)'
         into v_job_id
-        using v_drop_job_name, p_job_schedule, v_drop_command;
+        using v_drop_job_name, '* * * * *', v_drop_command;
 
       job_name := v_drop_job_name;
       job_id := v_job_id;
@@ -2733,7 +2720,7 @@ $$;
 
 -- Configures pg_cron jobs for partition provisioning, cleanup, and detach planning.
 --
--- Detach planning schedules per-partition jobs (via absurd.ensure_detach_jobs)
+-- Detach planning schedules per-partition jobs (via absurd.schedule_detach_jobs)
 -- that run raw DETACH ... CONCURRENTLY and follow-up drop checks.
 --
 -- Requires pg_cron to be installed (or compatible cron schema/functions).
@@ -2840,9 +2827,8 @@ begin
   v_detach_plan_job_name := 'absurd_detach_plan_' || v_job_suffix;
 
   v_detach_plan_command := format(
-    'select * from absurd.ensure_detach_jobs(%s, %L);',
-    v_queue_literal,
-    v_job_suffix
+    'select * from absurd.schedule_detach_jobs(%s);',
+    v_queue_literal
   );
 
   for v_existing_job_id in

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -2493,19 +2493,17 @@ begin
 end;
 $$;
 
--- Lists detach/drop commands for eligible partition tables.
+-- Lists eligible partition tables for detach/drop planning.
 --
 -- This does not execute detach directly.
--- Use this output from an external scheduler/executor.
+-- Callers should construct SQL locally from parent/partition names.
 create function absurd.list_detach_candidates (
   p_queue_name text default null
 )
   returns table (
     queue_name text,
     parent_table text,
-    partition_table text,
-    detach_sql text,
-    drop_sql text
+    partition_table text
   )
   language plpgsql
 as $$
@@ -2515,7 +2513,6 @@ declare
   v_parent_prefix text;
   v_parent_table text;
   v_parent_oid oid;
-  v_parent_has_default_partition boolean;
   v_part record;
   v_upper_uuid uuid;
   v_upper_ts timestamptz;
@@ -2557,15 +2554,6 @@ begin
       if v_parent_oid is null then
         continue;
       end if;
-
-      select exists (
-        select 1
-        from pg_inherits inh
-        join pg_class child on child.oid = inh.inhrelid
-        where inh.inhparent = v_parent_oid
-          and pg_get_expr(child.relpartbound, child.oid) = 'DEFAULT'
-      )
-      into v_parent_has_default_partition;
 
       for v_part in
         select
@@ -2610,24 +2598,6 @@ begin
         queue_name := v_queue.queue_name;
         parent_table := v_parent_table;
         partition_table := v_part.partition_name;
-        if coalesce(v_parent_has_default_partition, false) then
-          detach_sql := format(
-            'alter table absurd.%I detach partition absurd.%I',
-            v_parent_table,
-            v_part.partition_name
-          );
-        else
-          detach_sql := format(
-            'alter table absurd.%I detach partition absurd.%I concurrently',
-            v_parent_table,
-            v_part.partition_name
-          );
-        end if;
-        drop_sql := format(
-          'drop table if exists absurd.%I',
-          v_part.partition_name
-        );
-
         return next;
       end loop;
     end loop;
@@ -2807,9 +2777,7 @@ begin
     select
       ranked.queue_name,
       ranked.parent_table,
-      ranked.partition_table,
-      ranked.detach_sql,
-      ranked.drop_sql
+      ranked.partition_table
     from ranked
     where ranked.rn = 1
     order by ranked.queue_name, ranked.parent_table, ranked.partition_table
@@ -2863,15 +2831,14 @@ begin
       )
       into v_parent_has_default_partition;
 
-      if coalesce(v_parent_has_default_partition, false) then
-        v_detach_command := regexp_replace(
-          v_candidate.detach_sql,
-          ' concurrently$',
-          '',
-          'i'
-        );
-      else
-        v_detach_command := v_candidate.detach_sql;
+      v_detach_command := format(
+        'alter table absurd.%I detach partition absurd.%I',
+        v_candidate.parent_table,
+        v_candidate.partition_table
+      );
+
+      if not coalesce(v_parent_has_default_partition, false) then
+        v_detach_command := v_detach_command || ' concurrently';
       end if;
 
       execute 'select cron.schedule($1, $2, $3)'

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -403,8 +403,16 @@ begin
     return;
   end if;
 
-  -- Remove queue-scoped maintenance jobs.
-  perform absurd.disable_cron(p_queue_name);
+  -- Remove queue-scoped maintenance jobs only when pg_cron is available.
+  if to_regclass('cron.job') is not null and exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    perform absurd.disable_cron(p_queue_name);
+  end if;
 
   execute format('drop table if exists absurd.%I cascade', 'i_' || p_queue_name);
   execute format('drop table if exists absurd.%I cascade', 'w_' || p_queue_name);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import os
 import shlex
 import subprocess
-from datetime import datetime, timezone
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import psycopg
@@ -25,12 +26,15 @@ TEST_ROOT = Path(__file__).resolve().parent
 PROJECT_ROOT = TEST_ROOT.parent
 ABSURD_SQL = PROJECT_ROOT / "sql" / "absurd.sql"
 PGCRON_DOCKER_DIR = TEST_ROOT / "docker" / "pg16-pgcron"
-PGCRON_IMAGE = "absurd-test-postgres16-pgcron:16-1.6.7"
+PGCRON_IMAGE = "absurd-test-postgres16-pgcron:16-1.6.7-faketime6"
+PGCRON_FAKETIME_FILE = "/tmp/absurd-faketime.ts"
 
 
 class PgCronContainerControl:
     def __init__(self, container):
         self.container = container
+        self._anchor_time = None
+        self._anchor_monotonic = None
 
     def _exec_root(self, command):
         wrapped = self.container.get_wrapped_container()
@@ -42,28 +46,59 @@ class PgCronContainerControl:
             )
         return output
 
-    def set_system_time(self, when):
+    def _normalize_time(self, when):
         if isinstance(when, datetime):
             if when.tzinfo is None:
                 when = when.replace(tzinfo=timezone.utc)
-            when = when.astimezone(timezone.utc)
-            value = when.strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            value = str(when)
+            return when.astimezone(timezone.utc)
 
-        self._exec_root(f"date -u -s {shlex.quote(value)}")
+        text = str(when).strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def set_system_time(self, when):
+        normalized = self._normalize_time(when).replace(microsecond=0)
+        real_epoch = int(self._exec_root("date -u +%s"))
+        target_epoch = int(normalized.timestamp())
+        offset_seconds = target_epoch - real_epoch
+        # Use a relative offset so fake time continues to tick forward.
+        value = f"{offset_seconds:+d}"
+        self._exec_root(
+            f"printf '%s\\n' {shlex.quote(value)} > {shlex.quote(PGCRON_FAKETIME_FILE)}"
+        )
+        self._anchor_time = normalized
+        self._anchor_monotonic = time.monotonic()
 
     def advance_system_time(self, *, seconds=0, minutes=0, hours=0, days=0):
         total_seconds = int(seconds + minutes * 60 + hours * 3600 + days * 86400)
         if total_seconds == 0:
             return
 
-        current_epoch = int(self._exec_root("date -u +%s"))
-        self._exec_root(f"date -u -s @{current_epoch + total_seconds}")
+        current = self.get_system_time()
+        self.set_system_time(current + timedelta(seconds=total_seconds))
 
     def get_system_time(self):
-        value = self._exec_root("date -u +'%Y-%m-%dT%H:%M:%SZ'")
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if self._anchor_time is not None and self._anchor_monotonic is not None:
+            elapsed = max(0.0, time.monotonic() - self._anchor_monotonic)
+            return self._anchor_time + timedelta(seconds=elapsed)
+
+        value = self._exec_root(f"cat {shlex.quote(PGCRON_FAKETIME_FILE)}")
+        value = value.strip()
+        if value.startswith("@"):
+            return datetime.strptime(value[1:], "%Y-%m-%d %H:%M:%S").replace(
+                tzinfo=timezone.utc
+            )
+
+        try:
+            return datetime.now(timezone.utc) + timedelta(seconds=int(value))
+        except ValueError:
+            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(
+                tzinfo=timezone.utc
+            )
 
 
 def _docker_image_exists(image):
@@ -144,8 +179,8 @@ def pgcron_postgres_container():
             "-c",
             "cron.max_running_jobs=32",
         ],
-        cap_add=["SYS_TIME"],
     )
+
     container.start()
     control = PgCronContainerControl(container)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def postgres_container():
         container.stop()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def pgcron_postgres_container():
     _ensure_pgcron_image()
 
@@ -163,7 +163,7 @@ def db_dsn(postgres_container):
     return dsn
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def pgcron_db_dsn(pgcron_postgres_container):
     dsn = _normalize_dsn(pgcron_postgres_container.container.get_connection_url())
     script = ABSURD_SQL.read_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,9 @@ class PgCronContainerControl:
         result = wrapped.exec_run(["sh", "-lc", command], user="root")
         output = result.output.decode("utf-8", errors="replace").strip()
         if result.exit_code != 0:
-            raise RuntimeError(f"container command failed ({result.exit_code}): {command}\n{output}")
+            raise RuntimeError(
+                f"container command failed ({result.exit_code}): {command}\n{output}"
+            )
         return output
 
     def set_system_time(self, when):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+import shlex
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,6 +24,67 @@ if "DOCKER_HOST" not in os.environ:
 TEST_ROOT = Path(__file__).resolve().parent
 PROJECT_ROOT = TEST_ROOT.parent
 ABSURD_SQL = PROJECT_ROOT / "sql" / "absurd.sql"
+PGCRON_DOCKER_DIR = TEST_ROOT / "docker" / "pg16-pgcron"
+PGCRON_IMAGE = "absurd-test-postgres16-pgcron:16-1.6.7"
+
+
+class PgCronContainerControl:
+    def __init__(self, container):
+        self.container = container
+
+    def _exec_root(self, command):
+        wrapped = self.container.get_wrapped_container()
+        result = wrapped.exec_run(["sh", "-lc", command], user="root")
+        output = result.output.decode("utf-8", errors="replace").strip()
+        if result.exit_code != 0:
+            raise RuntimeError(f"container command failed ({result.exit_code}): {command}\n{output}")
+        return output
+
+    def set_system_time(self, when):
+        if isinstance(when, datetime):
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=timezone.utc)
+            when = when.astimezone(timezone.utc)
+            value = when.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            value = str(when)
+
+        self._exec_root(f"date -u -s {shlex.quote(value)}")
+
+    def advance_system_time(self, *, seconds=0, minutes=0, hours=0, days=0):
+        total_seconds = int(seconds + minutes * 60 + hours * 3600 + days * 86400)
+        if total_seconds == 0:
+            return
+
+        current_epoch = int(self._exec_root("date -u +%s"))
+        self._exec_root(f"date -u -s @{current_epoch + total_seconds}")
+
+    def get_system_time(self):
+        value = self._exec_root("date -u +'%Y-%m-%dT%H:%M:%SZ'")
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _docker_image_exists(image):
+    result = subprocess.run(
+        ["docker", "image", "inspect", image],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _ensure_pgcron_image():
+    if _docker_image_exists(PGCRON_IMAGE):
+        return
+
+    if not (PGCRON_DOCKER_DIR / "Dockerfile").exists():
+        raise RuntimeError(f"missing Dockerfile: {PGCRON_DOCKER_DIR / 'Dockerfile'}")
+
+    subprocess.run(
+        ["docker", "build", "-t", PGCRON_IMAGE, str(PGCRON_DOCKER_DIR)],
+        check=True,
+    )
 
 
 def _normalize_dsn(url):
@@ -61,10 +124,49 @@ def postgres_container():
 
 
 @pytest.fixture(scope="session")
+def pgcron_postgres_container():
+    _ensure_pgcron_image()
+
+    container = PostgresContainer(
+        PGCRON_IMAGE,
+        command=[
+            "postgres",
+            "-c",
+            "shared_preload_libraries=pg_cron",
+            "-c",
+            "cron.database_name=test",
+            "-c",
+            "cron.use_background_workers=on",
+            "-c",
+            "max_worker_processes=64",
+            "-c",
+            "cron.max_running_jobs=32",
+        ],
+        cap_add=["SYS_TIME"],
+    )
+    container.start()
+    control = PgCronContainerControl(container)
+    try:
+        yield control
+    finally:
+        container.stop()
+
+
+@pytest.fixture(scope="session")
 def db_dsn(postgres_container):
     dsn = _normalize_dsn(postgres_container.get_connection_url())
     script = ABSURD_SQL.read_text()
     with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute(script)
+    return dsn
+
+
+@pytest.fixture(scope="session")
+def pgcron_db_dsn(pgcron_postgres_container):
+    dsn = _normalize_dsn(pgcron_postgres_container.container.get_connection_url())
+    script = ABSURD_SQL.read_text()
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute("create extension if not exists pg_cron")
         conn.execute(script)
     return dsn
 
@@ -84,8 +186,30 @@ def db_connection(db_dsn):
 
 
 @pytest.fixture
+def pgcron_db_connection(pgcron_db_dsn):
+    with psycopg.connect(pgcron_db_dsn, autocommit=True) as conn:
+        conn.execute("set timezone to 'UTC'")
+        try:
+            yield conn
+        finally:
+            try:
+                conn.execute("set absurd.fake_now = default")
+            except psycopg.errors.InFailedSqlTransaction:
+                pass
+
+
+@pytest.fixture
 def client(db_connection):
     helper = AbsurdTestClient(db_connection)
+    try:
+        yield helper
+    finally:
+        helper.clear_fake_now()
+
+
+@pytest.fixture
+def pgcron_client(pgcron_db_connection):
+    helper = AbsurdTestClient(pgcron_db_connection)
     try:
         yield helper
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,8 +115,14 @@ class AbsurdTestClient:
     def __init__(self, conn):
         self.conn = conn
 
-    def create_queue(self, name):
-        self.conn.execute("select absurd.create_queue(%s)", (name,))
+    def create_queue(self, name, storage_mode=None):
+        if storage_mode is None or storage_mode == "unpartitioned":
+            self.conn.execute("select absurd.create_queue(%s)", (name,))
+        else:
+            self.conn.execute(
+                "select absurd.create_queue(%s, %s)",
+                (name, storage_mode),
+            )
 
     def drop_queue(self, name):
         self.conn.execute("select absurd.drop_queue(%s)", (name,))

--- a/tests/docker/pg16-pgcron/Dockerfile
+++ b/tests/docker/pg16-pgcron/Dockerfile
@@ -3,6 +3,8 @@ FROM postgres:16-alpine
 ARG PG_CRON_VERSION=v1.6.7
 
 RUN set -eux; \
+    apk add --no-cache \
+      libfaketime; \
     apk add --no-cache --virtual .build-deps \
       build-base \
       clang19 \
@@ -14,3 +16,32 @@ RUN set -eux; \
     make -C /tmp/pg_cron install; \
     rm -rf /tmp/pg_cron; \
     apk del .build-deps
+
+# Keep startup fake time far in the past so test jumps are always forward.
+# pg_cron minute schedules can stall after backward jumps.
+RUN printf '%s\n' '-50y' > /tmp/absurd-faketime.ts
+
+RUN mv /usr/local/bin/postgres /usr/local/bin/postgres.real && \
+    cat > /usr/local/bin/postgres <<'EOF' && \
+    chmod +x /usr/local/bin/postgres
+#!/bin/sh
+enable_faketime=1
+for arg in "$@"; do
+  case "$arg" in
+    *listen_addresses*)
+      # During docker-entrypoint temporary server startup, keep real time.
+      enable_faketime=0
+      break
+      ;;
+  esac
+done
+
+if [ "$enable_faketime" = "1" ]; then
+  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
+  export FAKETIME_TIMESTAMP_FILE=/tmp/absurd-faketime.ts
+  export FAKETIME_NO_CACHE=1
+  export FAKETIME_DONT_FAKE_MONOTONIC=1
+fi
+
+exec /usr/local/bin/postgres.real "$@"
+EOF

--- a/tests/docker/pg16-pgcron/Dockerfile
+++ b/tests/docker/pg16-pgcron/Dockerfile
@@ -1,0 +1,16 @@
+FROM postgres:16-alpine
+
+ARG PG_CRON_VERSION=v1.6.7
+
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps \
+      build-base \
+      clang19 \
+      git \
+      llvm19 \
+      postgresql16-dev; \
+    git clone --depth 1 --branch "${PG_CRON_VERSION}" https://github.com/citusdata/pg_cron.git /tmp/pg_cron; \
+    make -C /tmp/pg_cron; \
+    make -C /tmp/pg_cron install; \
+    rm -rf /tmp/pg_cron; \
+    apk del .build-deps

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -344,7 +344,7 @@ def test_detach_candidate_executes_detach_then_drop(monkeypatch):
                 "jobs",
                 "t_jobs",
                 "t_jobs_401",
-                'alter table absurd."t_jobs" detach partition absurd."t_jobs_401" concurrently',
+                'alter table absurd."t_jobs" detach partition absurd."t_jobs_401"',
                 'drop table if exists absurd."t_jobs_401"',
             ]
         ]

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -15,6 +15,11 @@ cmd_emit_event = MODULE["cmd_emit_event"]
 cmd_retry_task = MODULE["cmd_retry_task"]
 cmd_migrate = MODULE["cmd_migrate"]
 cmd_schema_version = MODULE["cmd_schema_version"]
+cmd_create_queue = MODULE["cmd_create_queue"]
+cmd_queue_policy = MODULE["cmd_queue_policy"]
+cmd_cron = MODULE["cmd_cron"]
+cmd_list_detach_candidates = MODULE["cmd_list_detach_candidates"]
+cmd_detach_candidate = MODULE["cmd_detach_candidate"]
 config_from_options = MODULE["config_from_options"]
 run_psql = MODULE["run_psql"]
 parse_migration_filename = MODULE["parse_migration_filename"]
@@ -175,6 +180,200 @@ def test_retry_task_allows_spawn_new_with_max_attempts(monkeypatch):
         captured["variables"]["options_json"]
         == '{"spawn_new": true, "max_attempts": 5}'
     )
+
+
+def test_create_queue_with_partitioned_storage_mode_uses_two_arg_function(monkeypatch):
+    captured = {}
+
+    def fake_run_psql(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return ""
+
+    monkeypatch.setitem(cmd_create_queue.__globals__, "run_psql", fake_run_psql)
+
+    cmd_create_queue(["--storage-mode", "partitioned", "jobs"])
+
+    assert (
+        captured["query"]
+        == "SELECT absurd.create_queue(:'queue_name', :'storage_mode');"
+    )
+    assert captured["variables"] == {
+        "queue_name": "jobs",
+        "storage_mode": "partitioned",
+    }
+
+
+def test_queue_policy_get_uses_policy_function(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return [
+            [
+                "jobs",
+                "partitioned",
+                "28 days",
+                "1 day",
+                "2592000",
+                "1000",
+                "none",
+                "30 days",
+            ]
+        ]
+
+    monkeypatch.setitem(cmd_queue_policy.__globals__, "run_psql_csv", fake_run_psql_csv)
+    monkeypatch.setitem(
+        cmd_queue_policy.__globals__,
+        "ensure_queue_exists",
+        lambda *_: None,
+    )
+
+    cmd_queue_policy(["jobs"])
+
+    assert "FROM absurd.get_queue_policy(:'queue_name')" in captured["query"]
+    assert captured["variables"]["queue_name"] == "jobs"
+
+
+def test_queue_policy_set_uses_parameterized_json_payload(monkeypatch):
+    captured = {}
+
+    def fake_run_psql(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return ""
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        return [
+            [
+                "jobs",
+                "partitioned",
+                "28 days",
+                "1 day",
+                "604800",
+                "100",
+                "none",
+                "30 days",
+            ]
+        ]
+
+    monkeypatch.setitem(cmd_queue_policy.__globals__, "run_psql", fake_run_psql)
+    monkeypatch.setitem(cmd_queue_policy.__globals__, "run_psql_csv", fake_run_psql_csv)
+    monkeypatch.setitem(
+        cmd_queue_policy.__globals__,
+        "ensure_queue_exists",
+        lambda *_: None,
+    )
+
+    cmd_queue_policy(
+        ["jobs", "--cleanup-ttl-seconds", "604800", "--cleanup-limit", "100"]
+    )
+
+    assert (
+        captured["query"]
+        == "SELECT absurd.set_queue_policy(:'queue_name', :'policy_json'::jsonb);"
+    )
+    assert captured["variables"]["queue_name"] == "jobs"
+    assert (
+        captured["variables"]["policy_json"]
+        == '{"cleanup_ttl_seconds": 604800, "cleanup_limit": 100}'
+    )
+
+
+def test_cron_enable_uses_enable_cron_function(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return [["absurd_cleanup_deadbeef0000", "1"]]
+
+    monkeypatch.setitem(cmd_cron.__globals__, "run_psql_csv", fake_run_psql_csv)
+
+    cmd_cron(["--enable", "--queue", "jobs"])
+
+    assert "FROM absurd.enable_cron(" in captured["query"]
+    assert captured["variables"]["queue_name"] == "jobs"
+
+
+def test_cron_disable_uses_disable_cron_function(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return []
+
+    monkeypatch.setitem(cmd_cron.__globals__, "run_psql_csv", fake_run_psql_csv)
+
+    cmd_cron(["--disable", "--queue", "jobs"])
+
+    assert "FROM absurd.disable_cron(:'queue_name')" in captured["query"]
+    assert captured["variables"]["queue_name"] == "jobs"
+
+
+def test_list_detach_candidates_queries_function(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return []
+
+    monkeypatch.setitem(
+        cmd_list_detach_candidates.__globals__,
+        "run_psql_csv",
+        fake_run_psql_csv,
+    )
+
+    cmd_list_detach_candidates(["--queue", "jobs"])
+
+    assert "FROM absurd.list_detach_candidates(:'queue_name')" in captured["query"]
+    assert captured["variables"]["queue_name"] == "jobs"
+
+
+def test_detach_candidate_executes_detach_then_drop(monkeypatch):
+    csv_calls = {}
+    psql_calls = []
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        csv_calls["query"] = query
+        csv_calls["variables"] = kwargs.get("variables")
+        return [
+            [
+                "jobs",
+                "t_jobs",
+                "t_jobs_401",
+                "1a2b3c4d5e6f",
+                'alter table absurd."t_jobs" detach partition absurd."t_jobs_401" concurrently',
+                'drop table if exists absurd."t_jobs_401"',
+            ]
+        ]
+
+    def fake_run_psql(config, query=None, **kwargs):
+        psql_calls.append((query, kwargs))
+        if "drop_detached_partition" in (query or ""):
+            return "t"
+        return ""
+
+    monkeypatch.setitem(
+        cmd_detach_candidate.__globals__, "run_psql_csv", fake_run_psql_csv
+    )
+    monkeypatch.setitem(cmd_detach_candidate.__globals__, "run_psql", fake_run_psql)
+
+    cmd_detach_candidate(["--queue", "jobs", "1a2b3c4d5e6f", "--drop"])
+
+    assert "FROM absurd.list_detach_candidates(:'queue_name')" in csv_calls["query"]
+    assert csv_calls["variables"]["queue_name"] == "jobs"
+    assert csv_calls["variables"]["candidate_hash"] == "1a2b3c4d5e6f"
+
+    assert len(psql_calls) == 2
+    assert "detach partition" in psql_calls[0][0]
+    assert (
+        psql_calls[1][0] == "SELECT absurd.drop_detached_partition(:'partition_table');"
+    )
+    assert psql_calls[1][1]["variables"]["partition_table"] == "t_jobs_401"
 
 
 def test_run_psql_sends_query_via_stdin_for_variable_expansion(monkeypatch):

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -216,6 +216,7 @@ def test_queue_policy_get_uses_policy_function(monkeypatch):
             [
                 "jobs",
                 "partitioned",
+                "enabled",
                 "28 days",
                 "1 day",
                 "2592000",
@@ -251,6 +252,7 @@ def test_queue_policy_set_uses_parameterized_json_payload(monkeypatch):
             [
                 "jobs",
                 "partitioned",
+                "enabled",
                 "28 days",
                 "1 day",
                 "7 days",
@@ -279,6 +281,47 @@ def test_queue_policy_set_uses_parameterized_json_payload(monkeypatch):
         captured["variables"]["policy_json"]
         == '{"cleanup_ttl": "7 days", "cleanup_limit": 100}'
     )
+
+
+def test_queue_policy_set_default_partition_uses_parameterized_json_payload(monkeypatch):
+    captured = {}
+
+    def fake_run_psql(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return ""
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        return [
+            [
+                "jobs",
+                "partitioned",
+                "disabled",
+                "28 days",
+                "1 day",
+                "7 days",
+                "100",
+                "none",
+                "30 days",
+            ]
+        ]
+
+    monkeypatch.setitem(cmd_queue_policy.__globals__, "run_psql", fake_run_psql)
+    monkeypatch.setitem(cmd_queue_policy.__globals__, "run_psql_csv", fake_run_psql_csv)
+    monkeypatch.setitem(
+        cmd_queue_policy.__globals__,
+        "ensure_queue_exists",
+        lambda *_: None,
+    )
+
+    cmd_queue_policy(["jobs", "--default-partition", "disabled"])
+
+    assert (
+        captured["query"]
+        == "SELECT absurd.set_queue_policy(:'queue_name', :'policy_json'::jsonb);"
+    )
+    assert captured["variables"]["queue_name"] == "jobs"
+    assert captured["variables"]["policy_json"] == '{"default_partition": "disabled"}'
 
 
 def test_cron_enable_uses_enable_cron_function(monkeypatch):

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -42,6 +42,8 @@ RemoteMigrationDiscoveryError = MODULE["RemoteMigrationDiscoveryError"]
         "-bad",
         "bad space",
         "bad'quote",
+        "   ",
+        "\t",
     ],
 )
 def test_validate_queue_name_accepts_supported_names(queue_name):
@@ -52,7 +54,6 @@ def test_validate_queue_name_accepts_supported_names(queue_name):
     "queue_name",
     [
         "",
-        "   ",
         "a" * 58,
     ],
 )

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -343,7 +343,6 @@ def test_detach_candidate_executes_detach_then_drop(monkeypatch):
                 "jobs",
                 "t_jobs",
                 "t_jobs_401",
-                "1a2b3c4d5e6f",
                 'alter table absurd."t_jobs" detach partition absurd."t_jobs_401" concurrently',
                 'drop table if exists absurd."t_jobs_401"',
             ]
@@ -360,11 +359,11 @@ def test_detach_candidate_executes_detach_then_drop(monkeypatch):
     )
     monkeypatch.setitem(cmd_detach_candidate.__globals__, "run_psql", fake_run_psql)
 
-    cmd_detach_candidate(["--queue", "jobs", "1a2b3c4d5e6f", "--drop"])
+    cmd_detach_candidate(["--queue", "jobs", "t_jobs_401", "--drop"])
 
     assert "FROM absurd.list_detach_candidates(:'queue_name')" in csv_calls["query"]
     assert csv_calls["variables"]["queue_name"] == "jobs"
-    assert csv_calls["variables"]["candidate_hash"] == "1a2b3c4d5e6f"
+    assert csv_calls["variables"]["partition_table"] == "t_jobs_401"
 
     assert len(psql_calls) == 2
     assert "detach partition" in psql_calls[0][0]

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -251,7 +251,7 @@ def test_queue_policy_set_uses_parameterized_json_payload(monkeypatch):
                 "partitioned",
                 "28 days",
                 "1 day",
-                "604800",
+                "7 days",
                 "100",
                 "none",
                 "30 days",
@@ -266,9 +266,7 @@ def test_queue_policy_set_uses_parameterized_json_payload(monkeypatch):
         lambda *_: None,
     )
 
-    cmd_queue_policy(
-        ["jobs", "--cleanup-ttl-seconds", "604800", "--cleanup-limit", "100"]
-    )
+    cmd_queue_policy(["jobs", "--cleanup-ttl", "7 days", "--cleanup-limit", "100"])
 
     assert (
         captured["query"]
@@ -277,7 +275,7 @@ def test_queue_policy_set_uses_parameterized_json_payload(monkeypatch):
     assert captured["variables"]["queue_name"] == "jobs"
     assert (
         captured["variables"]["policy_json"]
-        == '{"cleanup_ttl_seconds": 604800, "cleanup_limit": 100}'
+        == '{"cleanup_ttl": "7 days", "cleanup_limit": 100}'
     )
 
 

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -20,6 +20,7 @@ cmd_queue_policy = MODULE["cmd_queue_policy"]
 cmd_cron = MODULE["cmd_cron"]
 cmd_list_detach_candidates = MODULE["cmd_list_detach_candidates"]
 cmd_detach_candidate = MODULE["cmd_detach_candidate"]
+normalize_partition_table_name = MODULE["normalize_partition_table_name"]
 config_from_options = MODULE["config_from_options"]
 run_psql = MODULE["run_psql"]
 parse_migration_filename = MODULE["parse_migration_filename"]
@@ -372,6 +373,50 @@ def test_detach_candidate_executes_detach_then_drop(monkeypatch):
         psql_calls[1][0] == "SELECT absurd.drop_detached_partition(:'partition_table');"
     )
     assert psql_calls[1][1]["variables"]["partition_table"] == "t_jobs_401"
+
+
+def test_detach_candidate_accepts_dotted_partition_name(monkeypatch):
+    csv_calls = {}
+    psql_calls = []
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        csv_calls["query"] = query
+        csv_calls["variables"] = kwargs.get("variables")
+        return [
+            [
+                "foo.bar",
+                "t_foo.bar",
+                "t_foo.bar_401",
+                'alter table absurd."t_foo.bar" detach partition absurd."t_foo.bar_401"',
+                'drop table if exists absurd."t_foo.bar_401"',
+            ]
+        ]
+
+    def fake_run_psql(config, query=None, **kwargs):
+        psql_calls.append((query, kwargs))
+        return ""
+
+    monkeypatch.setitem(
+        cmd_detach_candidate.__globals__, "run_psql_csv", fake_run_psql_csv
+    )
+    monkeypatch.setitem(cmd_detach_candidate.__globals__, "run_psql", fake_run_psql)
+
+    cmd_detach_candidate(["--queue", "foo.bar", "t_foo.bar_401"])
+
+    assert "FROM absurd.list_detach_candidates(:'queue_name')" in csv_calls["query"]
+    assert csv_calls["variables"]["queue_name"] == "foo.bar"
+    assert csv_calls["variables"]["partition_table"] == "t_foo.bar_401"
+
+    assert len(psql_calls) == 1
+    assert "detach partition" in psql_calls[0][0]
+
+
+def test_normalize_partition_table_name_allows_dotted_partition_names():
+    assert normalize_partition_table_name("t_foo.bar_401") == "t_foo.bar_401"
+
+
+def test_normalize_partition_table_name_strips_absurd_prefix_for_dotted_names():
+    assert normalize_partition_table_name('absurd."t_foo.bar_401"') == "t_foo.bar_401"
 
 
 def test_run_psql_sends_query_via_stdin_for_variable_expansion(monkeypatch):

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -373,6 +373,8 @@ def test_list_detach_candidates_queries_function(monkeypatch):
     cmd_list_detach_candidates(["--queue", "jobs"])
 
     assert "FROM absurd.list_detach_candidates(:'queue_name')" in captured["query"]
+    assert "detach_sql" not in captured["query"].lower()
+    assert "drop_sql" not in captured["query"].lower()
     assert captured["variables"]["queue_name"] == "jobs"
 
 
@@ -388,13 +390,13 @@ def test_detach_candidate_executes_detach_then_drop(monkeypatch):
                 "jobs",
                 "t_jobs",
                 "t_jobs_401",
-                'alter table absurd."t_jobs" detach partition absurd."t_jobs_401"',
-                'drop table if exists absurd."t_jobs_401"',
             ]
         ]
 
     def fake_run_psql(config, query=None, **kwargs):
         psql_calls.append((query, kwargs))
+        if "pg_get_expr(child.relpartbound" in (query or ""):
+            return "t"
         if "drop_detached_partition" in (query or ""):
             return "t"
         return ""
@@ -407,15 +409,24 @@ def test_detach_candidate_executes_detach_then_drop(monkeypatch):
     cmd_detach_candidate(["--queue", "jobs", "t_jobs_401", "--drop"])
 
     assert "FROM absurd.list_detach_candidates(:'queue_name')" in csv_calls["query"]
+    assert "detach_sql" not in csv_calls["query"].lower()
+    assert "drop_sql" not in csv_calls["query"].lower()
     assert csv_calls["variables"]["queue_name"] == "jobs"
     assert csv_calls["variables"]["partition_table"] == "t_jobs_401"
 
-    assert len(psql_calls) == 2
-    assert "detach partition" in psql_calls[0][0]
-    assert (
-        psql_calls[1][0] == "SELECT absurd.drop_detached_partition(:'partition_table');"
+    assert len(psql_calls) >= 3
+    assert any("pg_get_expr(child.relpartbound" in (call[0] or "") for call in psql_calls)
+    assert any("detach partition" in (call[0] or "") for call in psql_calls)
+    assert any(
+        (call[0] or "") == "SELECT absurd.drop_detached_partition(:'partition_table');"
+        for call in psql_calls
     )
-    assert psql_calls[1][1]["variables"]["partition_table"] == "t_jobs_401"
+    drop_call = [
+        call
+        for call in psql_calls
+        if (call[0] or "") == "SELECT absurd.drop_detached_partition(:'partition_table');"
+    ][0]
+    assert drop_call[1]["variables"]["partition_table"] == "t_jobs_401"
 
 
 def test_detach_candidate_accepts_dotted_partition_name(monkeypatch):
@@ -430,13 +441,13 @@ def test_detach_candidate_accepts_dotted_partition_name(monkeypatch):
                 "foo.bar",
                 "t_foo.bar",
                 "t_foo.bar_401",
-                'alter table absurd."t_foo.bar" detach partition absurd."t_foo.bar_401"',
-                'drop table if exists absurd."t_foo.bar_401"',
             ]
         ]
 
     def fake_run_psql(config, query=None, **kwargs):
         psql_calls.append((query, kwargs))
+        if "pg_get_expr(child.relpartbound" in (query or ""):
+            return "t"
         return ""
 
     monkeypatch.setitem(
@@ -447,11 +458,13 @@ def test_detach_candidate_accepts_dotted_partition_name(monkeypatch):
     cmd_detach_candidate(["--queue", "foo.bar", "t_foo.bar_401"])
 
     assert "FROM absurd.list_detach_candidates(:'queue_name')" in csv_calls["query"]
+    assert "detach_sql" not in csv_calls["query"].lower()
+    assert "drop_sql" not in csv_calls["query"].lower()
     assert csv_calls["variables"]["queue_name"] == "foo.bar"
     assert csv_calls["variables"]["partition_table"] == "t_foo.bar_401"
 
-    assert len(psql_calls) == 1
-    assert "detach partition" in psql_calls[0][0]
+    assert len(psql_calls) >= 2
+    assert any("detach partition" in (call[0] or "") for call in psql_calls)
 
 
 def test_normalize_partition_table_name_allows_dotted_partition_names():

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -213,8 +213,8 @@ def test_schedule_detach_jobs_schedules_detach_and_drop_jobs(client):
     assert detach_jobs
     assert drop_jobs
     assert "detach partition" in detach_jobs[0][2].lower()
-    assert "concurrently" in detach_jobs[0][2].lower()
-    assert "cron.unschedule" in detach_jobs[0][2].lower()
+    assert "concurrently" not in detach_jobs[0][2].lower()
+    assert "cron.unschedule" not in detach_jobs[0][2].lower()
     assert "absurd.drop_detached_partition" in drop_jobs[0][2]
 
     # Idempotent: second pass should create no new jobs.

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -317,3 +317,49 @@ def test_disable_cron_without_queue_only_removes_global_jobs(client):
     assert remaining[0][0].startswith("absurd_cleanup_")
     assert remaining[1][0].startswith("absurd_detach_plan_")
     assert remaining[2][0].startswith("absurd_partitions_")
+
+
+def test_drop_queue_unschedules_queue_scoped_cron_jobs(client):
+    queue = "cron-drop-queue"
+    client.create_queue(queue, storage_mode="partitioned")
+    _install_mock_cron(client.conn)
+
+    client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(%s, %s, %s)
+        """,
+        (queue, "*/20 * * * *", "11 * * * *"),
+    )
+
+    scope = client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
+
+    # Seed queue-scoped detach/drop run jobs too.
+    client.conn.execute(
+        """
+        insert into cron.job (jobname, schedule, command)
+        values
+          (%s, '* * * * *', 'select 1'),
+          (%s, '* * * * *', 'select 1')
+        """,
+        (
+            f"absurd_detach_run_{scope}_demo",
+            f"absurd_drop_run_{scope}_demo",
+        ),
+    )
+
+    client.drop_queue(queue)
+
+    remaining = client.conn.execute(
+        """
+        select jobname
+        from cron.job
+        where jobname like %s
+        order by jobname
+        """,
+        (f"absurd%{scope}%",),
+    ).fetchall()
+    assert remaining == []

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -72,7 +72,7 @@ def test_cleanup_all_queues_runs_batch_for_all_queues(client):
         client.emit_event(queue, f"event:{spawned.task_id}", {"queue": queue})
         client.conn.execute(
             "select absurd.set_queue_policy(%s, %s::jsonb)",
-            (queue, '{"cleanup_ttl_seconds": 3600, "cleanup_limit": 10}'),
+            (queue, '{"cleanup_ttl": "3600 seconds", "cleanup_limit": 10}'),
         )
 
     client.set_fake_now(base + timedelta(days=2))

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -134,7 +134,7 @@ def test_enable_cron_schedules_partition_cleanup_and_detach_planner_jobs(client)
     assert cleanup_job[1] == "7 * * * *"
     assert "absurd.cleanup_all_queues('cron-partitioned')" in cleanup_job[2]
     assert detach_plan_job[1] == "29 * * * *"
-    assert "absurd.ensure_detach_jobs('cron-partitioned'" in detach_plan_job[2]
+    assert "absurd.schedule_detach_jobs('cron-partitioned')" in detach_plan_job[2]
     assert partition_job[1] == "*/15 * * * *"
     assert "absurd.ensure_partitions('cron-partitioned')" in partition_job[2]
 
@@ -160,7 +160,7 @@ def test_enable_cron_schedules_partition_cleanup_and_detach_planner_jobs(client)
     assert job_count[0] == 3
 
 
-def test_ensure_detach_jobs_schedules_detach_and_drop_jobs(client):
+def test_schedule_detach_jobs_schedules_detach_and_drop_jobs(client):
     queue = "cron-detach-jobs"
     base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
     client.set_fake_now(base)
@@ -173,14 +173,18 @@ def test_ensure_detach_jobs_schedules_detach_and_drop_jobs(client):
     _install_mock_cron(client.conn)
 
     client.set_fake_now(base + timedelta(days=90))
+    scope = client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
 
     scheduled = client.conn.execute(
         """
         select job_name, job_kind, partition_table
-        from absurd.ensure_detach_jobs(%s, %s, %s)
+        from absurd.schedule_detach_jobs(%s)
         order by job_name
         """,
-        (queue, "qscope", "*/2 * * * *"),
+        (queue,),
     ).fetchall()
 
     assert scheduled
@@ -191,20 +195,23 @@ def test_ensure_detach_jobs_schedules_detach_and_drop_jobs(client):
         """
         select jobname, schedule, command
         from cron.job
-        where jobname like 'absurd_detach_run_qscope_%'
-           or jobname like 'absurd_drop_run_qscope_%'
+        where jobname like %s
+           or jobname like %s
         order by jobname
-        """
+        """,
+        (f"absurd_detach_run_{scope}_%", f"absurd_drop_run_{scope}_%"),
     ).fetchall()
 
     assert jobs
     for _, schedule, _ in jobs:
-        assert schedule == "*/2 * * * *"
+        assert schedule == "* * * * *"
 
     detach_jobs = [
-        job for job in jobs if job[0].startswith("absurd_detach_run_qscope_")
+        job for job in jobs if job[0].startswith(f"absurd_detach_run_{scope}_")
     ]
-    drop_jobs = [job for job in jobs if job[0].startswith("absurd_drop_run_qscope_")]
+    drop_jobs = [
+        job for job in jobs if job[0].startswith(f"absurd_drop_run_{scope}_")
+    ]
     assert detach_jobs
     assert drop_jobs
     assert "detach partition" in detach_jobs[0][2].lower()
@@ -214,8 +221,8 @@ def test_ensure_detach_jobs_schedules_detach_and_drop_jobs(client):
 
     # Idempotent: second pass should create no new jobs.
     scheduled_again = client.conn.execute(
-        "select * from absurd.ensure_detach_jobs(%s, %s, %s)",
-        (queue, "qscope", "*/2 * * * *"),
+        "select * from absurd.schedule_detach_jobs(%s)",
+        (queue,),
     ).fetchall()
     assert scheduled_again == []
 
@@ -241,14 +248,10 @@ def test_disable_cron_unschedules_queue_jobs(client):
     )
 
     # Seed per-partition detach/drop jobs for this queue scope.
-    scope = client.conn.execute(
-        "select substr(md5(%s), 1, 12)",
-        (queue,),
-    ).fetchone()[0]
     client.set_fake_now(base + timedelta(days=90))
     client.conn.execute(
-        "select * from absurd.ensure_detach_jobs(%s, %s, %s)",
-        (queue, scope, "*/5 * * * *"),
+        "select * from absurd.schedule_detach_jobs(%s)",
+        (queue,),
     )
 
     removed = client.conn.execute(

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -173,6 +173,25 @@ def test_schedule_detach_jobs_schedules_detach_and_drop_jobs(client):
     _install_mock_cron(client.conn)
 
     client.set_fake_now(base + timedelta(days=90))
+
+    expected_oldest = dict(
+        client.conn.execute(
+            """
+            select parent_table, min(partition_table) as partition_table
+            from absurd.list_detach_candidates(%s)
+            group by parent_table
+            order by parent_table
+            """,
+            (queue,),
+        ).fetchall()
+    )
+    assert set(expected_oldest.keys()) == {
+        f"t_{queue}",
+        f"r_{queue}",
+        f"c_{queue}",
+        f"w_{queue}",
+    }
+
     scope = client.conn.execute(
         "select substr(md5(%s), 1, 12)",
         (queue,),
@@ -190,6 +209,12 @@ def test_schedule_detach_jobs_schedules_detach_and_drop_jobs(client):
     assert scheduled
     kinds = {row[1] for row in scheduled}
     assert kinds == {"detach", "drop"}
+
+    scheduled_detach = [row for row in scheduled if row[1] == "detach"]
+    scheduled_detach_by_parent = {
+        row[2].rsplit("_", 1)[0]: row[2] for row in scheduled_detach
+    }
+    assert scheduled_detach_by_parent == expected_oldest
 
     jobs = client.conn.execute(
         """
@@ -223,6 +248,77 @@ def test_schedule_detach_jobs_schedules_detach_and_drop_jobs(client):
         (queue,),
     ).fetchall()
     assert scheduled_again == []
+
+    # Keep only one drop job for the task parent; all other parent pipelines
+    # should be schedulable, but that parent must remain blocked.
+    t_parent = f"t_{queue}"
+    t_partition = expected_oldest[t_parent]
+    client.conn.execute(
+        """
+        delete from cron.job
+        where not (
+          jobname like 'absurd_drop_run_%%'
+          and position(%s in command) > 0
+        )
+        """,
+        (f"'{t_partition}'",),
+    )
+
+    scheduled_after_partial_cleanup = client.conn.execute(
+        """
+        select job_name, job_kind, partition_table
+        from absurd.schedule_detach_jobs(%s)
+        where job_kind = 'detach'
+        order by partition_table
+        """,
+        (queue,),
+    ).fetchall()
+
+    scheduled_after_by_parent = {
+        row[2].rsplit("_", 1)[0]: row[2] for row in scheduled_after_partial_cleanup
+    }
+    assert t_parent not in scheduled_after_by_parent
+    assert scheduled_after_by_parent == {
+        parent: partition
+        for parent, partition in expected_oldest.items()
+        if parent != t_parent
+    }
+
+
+def test_schedule_detach_jobs_uses_concurrently_when_default_partition_disabled(client):
+    queue = "cron-detach-concurrently"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (
+            queue,
+            '{"detach_mode": "empty", "detach_min_age": "0 days", "default_partition": "disabled"}',
+        ),
+    )
+
+    _install_mock_cron(client.conn)
+
+    client.set_fake_now(base + timedelta(days=90))
+    scope = client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
+
+    client.conn.execute("select * from absurd.schedule_detach_jobs(%s)", (queue,))
+
+    detach_jobs = client.conn.execute(
+        """
+        select command
+        from cron.job
+        where jobname like %s
+        order by jobname
+        """,
+        (f"absurd_detach_run_{scope}_%",),
+    ).fetchall()
+    assert detach_jobs
+    assert all("concurrently" in row[0].lower() for row in detach_jobs)
 
 
 def test_disable_cron_unschedules_queue_jobs(client):

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,0 +1,316 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _install_mock_cron(conn):
+    conn.execute("create schema if not exists cron")
+    conn.execute("drop table if exists cron.job")
+    conn.execute(
+        """
+        create table cron.job (
+          jobid bigint generated always as identity primary key,
+          jobname text not null,
+          schedule text not null,
+          command text not null
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        create or replace function cron.schedule(
+          p_jobname text,
+          p_schedule text,
+          p_command text
+        )
+          returns bigint
+          language plpgsql
+        as $$
+        declare
+          v_jobid bigint;
+        begin
+          insert into cron.job (jobname, schedule, command)
+          values (p_jobname, p_schedule, p_command)
+          returning jobid into v_jobid;
+          return v_jobid;
+        end;
+        $$;
+        """
+    )
+
+    conn.execute(
+        """
+        create or replace function cron.unschedule(
+          p_jobid bigint
+        )
+          returns boolean
+          language plpgsql
+        as $$
+        begin
+          delete from cron.job where jobid = p_jobid;
+          return found;
+        end;
+        $$;
+        """
+    )
+
+
+def test_cleanup_all_queues_runs_batch_for_all_queues(client):
+    q1 = "cleanup-all-1"
+    q2 = "cleanup-all-2"
+    client.create_queue(q1)
+    client.create_queue(q2)
+
+    base = datetime(2024, 6, 1, 10, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+
+    for queue in [q1, q2]:
+        spawned = client.spawn_task(queue, "cleanup-task", {"q": queue})
+        claim = client.claim_tasks(queue)[0]
+        client.complete_run(queue, claim["run_id"], {"ok": True})
+        client.emit_event(queue, f"event:{spawned.task_id}", {"queue": queue})
+        client.conn.execute(
+            "select absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, '{"cleanup_ttl_seconds": 3600, "cleanup_limit": 10}'),
+        )
+
+    client.set_fake_now(base + timedelta(days=2))
+
+    rows = client.conn.execute(
+        """
+        select queue_name, tasks_deleted, events_deleted
+        from absurd.cleanup_all_queues()
+        order by queue_name
+        """,
+    ).fetchall()
+
+    assert rows == [(q1, 1, 1), (q2, 1, 1)]
+
+
+def test_enable_cron_requires_cron_schema(client):
+    if client.conn.execute("select to_regclass('cron.job')").fetchone()[0] is not None:
+        pytest.skip("cron.job already exists in this environment")
+
+    with pytest.raises(Exception):
+        client.conn.execute("select * from absurd.enable_cron()")
+
+
+def test_enable_cron_schedules_partition_cleanup_and_detach_planner_jobs(client):
+    queue = "cron-partitioned"
+    client.create_queue(queue, storage_mode="partitioned")
+    _install_mock_cron(client.conn)
+
+    rows = client.conn.execute(
+        """
+        select job_name, job_id
+        from absurd.enable_cron(
+          %s,
+          %s,
+          %s
+        )
+        order by job_name
+        """,
+        (
+            queue,
+            "*/15 * * * *",
+            "7 * * * *",
+        ),
+    ).fetchall()
+
+    assert len(rows) == 3
+    assert rows[0][0].startswith("absurd_cleanup_")
+    assert rows[1][0].startswith("absurd_detach_plan_")
+    assert rows[2][0].startswith("absurd_partitions_")
+
+    jobs = client.conn.execute(
+        "select jobname, schedule, command from cron.job order by jobname"
+    ).fetchall()
+    assert len(jobs) == 3
+
+    cleanup_job = jobs[0]
+    detach_plan_job = jobs[1]
+    partition_job = jobs[2]
+    assert cleanup_job[1] == "7 * * * *"
+    assert "absurd.cleanup_all_queues('cron-partitioned')" in cleanup_job[2]
+    assert detach_plan_job[1] == "29 * * * *"
+    assert "absurd.ensure_detach_jobs('cron-partitioned'" in detach_plan_job[2]
+    assert partition_job[1] == "*/15 * * * *"
+    assert "absurd.ensure_partitions('cron-partitioned')" in partition_job[2]
+
+    # Re-enable with different schedules; old jobs should be replaced, not duplicated.
+    client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(
+          %s,
+          %s,
+          %s
+        )
+        """,
+        (
+            queue,
+            "0 * * * *",
+            "0 3 * * *",
+        ),
+    )
+
+    job_count = client.conn.execute("select count(*) from cron.job").fetchone()
+    assert job_count is not None
+    assert job_count[0] == 3
+
+
+def test_ensure_detach_jobs_schedules_detach_and_drop_jobs(client):
+    queue = "cron-detach-jobs"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"detach_mode": "empty", "detach_min_age": "0 days"}'),
+    )
+
+    _install_mock_cron(client.conn)
+
+    client.set_fake_now(base + timedelta(days=90))
+
+    scheduled = client.conn.execute(
+        """
+        select job_name, job_kind, partition_table
+        from absurd.ensure_detach_jobs(%s, %s, %s)
+        order by job_name
+        """,
+        (queue, "qscope", "*/2 * * * *"),
+    ).fetchall()
+
+    assert scheduled
+    kinds = {row[1] for row in scheduled}
+    assert kinds == {"detach", "drop"}
+
+    jobs = client.conn.execute(
+        """
+        select jobname, schedule, command
+        from cron.job
+        where jobname like 'absurd_detach_run_qscope_%'
+           or jobname like 'absurd_drop_run_qscope_%'
+        order by jobname
+        """
+    ).fetchall()
+
+    assert jobs
+    for _, schedule, _ in jobs:
+        assert schedule == "*/2 * * * *"
+
+    detach_jobs = [
+        job for job in jobs if job[0].startswith("absurd_detach_run_qscope_")
+    ]
+    drop_jobs = [job for job in jobs if job[0].startswith("absurd_drop_run_qscope_")]
+    assert detach_jobs
+    assert drop_jobs
+    assert "detach partition" in detach_jobs[0][2].lower()
+    assert "concurrently" in detach_jobs[0][2].lower()
+    assert "cron.unschedule" in detach_jobs[0][2].lower()
+    assert "absurd.drop_detached_partition" in drop_jobs[0][2]
+
+    # Idempotent: second pass should create no new jobs.
+    scheduled_again = client.conn.execute(
+        "select * from absurd.ensure_detach_jobs(%s, %s, %s)",
+        (queue, "qscope", "*/2 * * * *"),
+    ).fetchall()
+    assert scheduled_again == []
+
+
+def test_disable_cron_unschedules_queue_jobs(client):
+    queue = "cron-disable-queue"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+    _install_mock_cron(client.conn)
+
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"detach_mode": "empty", "detach_min_age": "0 days"}'),
+    )
+
+    client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(%s, %s, %s)
+        """,
+        (queue, "*/10 * * * *", "7 * * * *"),
+    )
+
+    # Seed per-partition detach/drop jobs for this queue scope.
+    scope = client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
+    client.set_fake_now(base + timedelta(days=90))
+    client.conn.execute(
+        "select * from absurd.ensure_detach_jobs(%s, %s, %s)",
+        (queue, scope, "*/5 * * * *"),
+    )
+
+    removed = client.conn.execute(
+        """
+        select job_name, job_id
+        from absurd.disable_cron(%s)
+        order by job_name
+        """,
+        (queue,),
+    ).fetchall()
+
+    assert len(removed) >= 3
+    removed_names = [row[0] for row in removed]
+    assert any(name.startswith("absurd_cleanup_") for name in removed_names)
+    assert any(name.startswith("absurd_detach_plan_") for name in removed_names)
+    assert any(name.startswith("absurd_partitions_") for name in removed_names)
+    assert any(name.startswith("absurd_detach_run_") for name in removed_names)
+    assert any(name.startswith("absurd_drop_run_") for name in removed_names)
+
+    # Idempotent: disabling again removes nothing.
+    removed_again = client.conn.execute(
+        "select * from absurd.disable_cron(%s)",
+        (queue,),
+    ).fetchall()
+    assert removed_again == []
+
+
+def test_disable_cron_without_queue_only_removes_global_jobs(client):
+    queue = "cron-disable-global"
+    client.create_queue(queue, storage_mode="partitioned")
+    _install_mock_cron(client.conn)
+
+    # Queue-specific jobs.
+    client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(%s, %s, %s)
+        """,
+        (queue, "*/20 * * * *", "11 * * * *"),
+    )
+
+    # Global jobs.
+    client.conn.execute("select * from absurd.enable_cron()")
+
+    removed = client.conn.execute(
+        """
+        select job_name
+        from absurd.disable_cron()
+        order by job_name
+        """
+    ).fetchall()
+
+    assert [row[0] for row in removed] == [
+        "absurd_cleanup_all",
+        "absurd_detach_plan_all",
+        "absurd_partitions_all",
+    ]
+
+    remaining = client.conn.execute(
+        "select jobname from cron.job order by jobname"
+    ).fetchall()
+    assert len(remaining) == 3
+    assert remaining[0][0].startswith("absurd_cleanup_")
+    assert remaining[1][0].startswith("absurd_detach_plan_")
+    assert remaining[2][0].startswith("absurd_partitions_")

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -209,9 +209,7 @@ def test_schedule_detach_jobs_schedules_detach_and_drop_jobs(client):
     detach_jobs = [
         job for job in jobs if job[0].startswith(f"absurd_detach_run_{scope}_")
     ]
-    drop_jobs = [
-        job for job in jobs if job[0].startswith(f"absurd_drop_run_{scope}_")
-    ]
+    drop_jobs = [job for job in jobs if job[0].startswith(f"absurd_drop_run_{scope}_")]
     assert detach_jobs
     assert drop_jobs
     assert "detach partition" in detach_jobs[0][2].lower()

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -13,7 +13,9 @@ def _wait_until(predicate, *, timeout=30.0, interval=0.25, message="condition no
     raise AssertionError(message)
 
 
-def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_postgres_container):
+def test_pgcron_time_jump_executes_detach_and_drop_jobs(
+    pgcron_client, pgcron_postgres_container
+):
     queue = "cron-live-detach"
     base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
 
@@ -97,15 +99,17 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_po
 
     _wait_until(
         lambda: (
-            (row := pgcron_client.conn.execute(
-                """
+            (
+                row := pgcron_client.conn.execute(
+                    """
                 select status
                 from cron.job_run_details
                 where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
                 order by runid desc
                 limit 1
                 """,
-            ).fetchone())
+                ).fetchone()
+            )
             is not None
             and row[0] != "running"
         ),
@@ -166,11 +170,13 @@ def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
     ).fetchone()[0]
 
     _wait_until(
-        lambda: pgcron_client.conn.execute(
-            "select count(*) from cron.job where jobname like %s",
-            (f"absurd%{scope}%",),
-        ).fetchone()[0]
-        >= 3,
+        lambda: (
+            pgcron_client.conn.execute(
+                "select count(*) from cron.job where jobname like %s",
+                (f"absurd%{scope}%",),
+            ).fetchone()[0]
+            >= 3
+        ),
         timeout=10.0,
         message="expected queue-scoped cron jobs were not created",
     )
@@ -221,8 +227,10 @@ def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
     )
 
     _wait_until(
-        lambda: pgcron_client.count_tasks(queue) == 1
-        and pgcron_client.count_events(queue) == 1,
+        lambda: (
+            pgcron_client.count_tasks(queue) == 1
+            and pgcron_client.count_events(queue) == 1
+        ),
         timeout=20.0,
         message="cleanup cron job did not remove expected old rows",
     )
@@ -380,8 +388,8 @@ def test_ensure_partitions_and_default_partition_fallback_with_real_time(
         (spawned.run_id,),
     ).fetchone()[0]
 
-    assert task_partition.replace('"', '') == f"absurd.t_{queue}_d"
-    assert run_partition.replace('"', '') == f"absurd.r_{queue}_d"
+    assert task_partition.replace('"', "") == f"absurd.t_{queue}_d"
+    assert run_partition.replace('"', "") == f"absurd.r_{queue}_d"
 
 
 def test_tasks_in_default_partition_are_claimable_and_completable(
@@ -418,8 +426,8 @@ def test_tasks_in_default_partition_are_claimable_and_completable(
         (spawned.run_id,),
     ).fetchone()[0]
 
-    assert task_partition.replace('"', '') == f"absurd.t_{queue}_d"
-    assert run_partition.replace('"', '') == f"absurd.r_{queue}_d"
+    assert task_partition.replace('"', "") == f"absurd.t_{queue}_d"
+    assert run_partition.replace('"', "") == f"absurd.r_{queue}_d"
 
     claim = pgcron_client.claim_tasks(queue, worker="default-worker")
     assert claim

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -13,18 +13,8 @@ def _wait_until(predicate, *, timeout=30.0, interval=0.25, message="condition no
     raise AssertionError(message)
 
 
-def _register_queue_cleanup(request, client, queue):
-    def _cleanup():
-        try:
-            client.drop_queue(queue)
-        except Exception:
-            pass
-
-    request.addfinalizer(_cleanup)
-
-
 def test_pgcron_time_jump_executes_detach_and_drop_jobs(
-    pgcron_client, pgcron_postgres_container, request
+    pgcron_client, pgcron_postgres_container
 ):
     queue = "cron-live-detach"
     base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
@@ -32,7 +22,6 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
     pgcron_postgres_container.set_system_time(base)
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
     pgcron_client.conn.execute(
         "select absurd.set_queue_policy(%s, %s::jsonb)",
         (queue, '{"detach_mode": "empty", "detach_min_age": "0 days"}'),
@@ -178,11 +167,10 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
         time.sleep(1.0)
 
 
-def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client, request):
+def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
     queue = "cron-drop-live"
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
     pgcron_client.conn.execute(
         """
         select *
@@ -220,7 +208,6 @@ def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client, request):
 def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
     pgcron_client,
     pgcron_postgres_container,
-    request,
 ):
     queue = "cron-cleanup-live"
     base = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
@@ -228,7 +215,6 @@ def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
     pgcron_postgres_container.set_system_time(base)
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
     pgcron_client.conn.execute(
         "select absurd.set_queue_policy(%s, %s::jsonb)",
         (queue, '{"cleanup_ttl": "3600 seconds", "cleanup_limit": 100}'),
@@ -283,14 +269,12 @@ def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
 def test_partitioned_idempotency_key_survives_week_boundary_with_real_time(
     pgcron_client,
     pgcron_postgres_container,
-    request,
 ):
     queue = "cron-idempotency-live"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
 
     first = pgcron_client.spawn_task(
         queue,
@@ -325,7 +309,6 @@ def test_partitioned_idempotency_key_survives_week_boundary_with_real_time(
 def test_partitioned_events_resume_across_week_boundary_with_real_time(
     pgcron_client,
     pgcron_postgres_container,
-    request,
 ):
     queue = "cron-events-live"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
@@ -334,7 +317,6 @@ def test_partitioned_events_resume_across_week_boundary_with_real_time(
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
 
     spawned = pgcron_client.spawn_task(queue, "waiter", {"step": 1})
     claim = pgcron_client.claim_tasks(queue)[0]
@@ -371,14 +353,12 @@ def test_partitioned_events_resume_across_week_boundary_with_real_time(
 def test_ensure_partitions_and_default_partition_fallback_with_real_time(
     pgcron_client,
     pgcron_postgres_container,
-    request,
 ):
     queue = "cron-default-live"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
 
     # C1: ensure_partitions can precreate future week partitions.
     pgcron_client.conn.execute(
@@ -430,14 +410,12 @@ def test_ensure_partitions_and_default_partition_fallback_with_real_time(
 def test_tasks_in_default_partition_are_claimable_and_completable(
     pgcron_client,
     pgcron_postgres_container,
-    request,
 ):
     queue = "cron-default-taskflow"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
-    _register_queue_cleanup(request, pgcron_client, queue)
 
     # Keep partition window narrow so a far-future task lands in default.
     pgcron_client.conn.execute(

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -120,3 +120,39 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_po
         ).fetchone()[0]
         is not None
     )
+
+
+def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
+    queue = "cron-drop-live"
+
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+    pgcron_client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(%s, %s, %s, %s)
+        """,
+        (queue, "1 second", "1 second", "1 second"),
+    )
+
+    scope = pgcron_client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
+
+    _wait_until(
+        lambda: pgcron_client.conn.execute(
+            "select count(*) from cron.job where jobname like %s",
+            (f"absurd%{scope}%",),
+        ).fetchone()[0]
+        >= 3,
+        timeout=10.0,
+        message="expected queue-scoped cron jobs were not created",
+    )
+
+    pgcron_client.drop_queue(queue)
+
+    remaining = pgcron_client.conn.execute(
+        "select count(*) from cron.job where jobname like %s",
+        (f"absurd%{scope}%",),
+    ).fetchone()[0]
+    assert remaining == 0

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -1,0 +1,122 @@
+import time
+
+
+def _wait_until(predicate, *, timeout=30.0, interval=0.25, message="condition not met"):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError(message)
+
+
+def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_postgres_container):
+    queue = "cron-live-detach"
+
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+    pgcron_client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"detach_mode": "empty", "detach_min_age": "0 days"}'),
+    )
+
+    pgcron_client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(
+          %s,
+          %s,
+          %s,
+          %s
+        )
+        """,
+        (
+            queue,
+            "0 0 1 1 *",
+            "0 0 1 1 *",
+            "1 second",
+        ),
+    )
+
+    candidate_row = pgcron_client.conn.execute(
+        """
+        select partition_table
+        from absurd.list_detach_candidates(%s)
+        where parent_table in (%s, %s)
+        order by partition_table
+        limit 1
+        """,
+        (queue, f"t_{queue}", f"r_{queue}"),
+    ).fetchone()
+    assert candidate_row is not None
+    partition_table = candidate_row[0]
+
+    scope = pgcron_client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
+
+    _wait_until(
+        lambda: pgcron_client.conn.execute(
+            "select exists (select 1 from cron.job where jobname like %s or jobname like %s)",
+            (f"absurd_detach_run_{scope}_%", f"absurd_drop_run_{scope}_%"),
+        ).fetchone()[0],
+        timeout=20.0,
+        message="pg_cron did not schedule detach/drop run jobs via planner",
+    )
+
+    deadline = time.monotonic() + 45.0
+    while True:
+        row = pgcron_client.conn.execute(
+            """
+            select status, return_message
+            from cron.job_run_details
+            where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
+            order by runid desc
+            limit 1
+            """,
+        ).fetchone()
+
+        if row is not None:
+            break
+        if time.monotonic() >= deadline:
+            raise AssertionError("detach job never executed through pg_cron")
+
+        # The per-partition detach/drop jobs use minute schedules. Move wall
+        # clock forward so pg_cron detects due minutes without waiting in real
+        # time.
+        pgcron_postgres_container.advance_system_time(minutes=2)
+        time.sleep(1.0)
+
+    detach_row = pgcron_client.conn.execute(
+        """
+        select status, return_message
+        from cron.job_run_details
+        where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
+        order by runid desc
+        limit 1
+        """,
+    ).fetchone()
+    assert detach_row is not None
+    assert detach_row[0] == "failed"
+    assert "cannot be executed from a function" in (detach_row[1] or "")
+
+    drop_ran = pgcron_client.conn.execute(
+        """
+        select exists (
+          select 1
+          from cron.job_run_details
+          where command like 'select absurd.drop_detached_partition(%'
+        )
+        """
+    ).fetchone()[0]
+    assert drop_ran
+
+    # Since DETACH ... CONCURRENTLY fails under pg_cron execution context,
+    # the source partition is still present.
+    assert (
+        pgcron_client.conn.execute(
+            "select to_regclass(%s)",
+            (f"absurd.{partition_table}",),
+        ).fetchone()[0]
+        is not None
+    )

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -167,6 +167,77 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
         time.sleep(1.0)
 
 
+def test_pgcron_detach_uses_concurrently_when_default_partition_disabled(
+    pgcron_client, pgcron_postgres_container
+):
+    queue = "cron-live-detach-concurrent"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+
+    pgcron_postgres_container.set_system_time(base)
+
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+    pgcron_client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (
+            queue,
+            '{"detach_mode": "empty", "detach_min_age": "0 days", "default_partition": "disabled"}',
+        ),
+    )
+
+    pgcron_client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(
+          %s,
+          %s,
+          %s,
+          %s
+        )
+        """,
+        (
+            queue,
+            "0 0 1 1 *",
+            "0 0 1 1 *",
+            "1 second",
+        ),
+    )
+
+    pgcron_postgres_container.advance_system_time(days=120)
+
+    scope = pgcron_client.conn.execute(
+        "select substr(md5(%s), 1, 12)",
+        (queue,),
+    ).fetchone()[0]
+
+    _wait_until(
+        lambda: pgcron_client.conn.execute(
+            "select exists (select 1 from cron.job where jobname like %s)",
+            (f"absurd_detach_run_{scope}_%",),
+        ).fetchone()[0],
+        timeout=20.0,
+        message="pg_cron did not schedule detach run jobs",
+    )
+
+    deadline = time.monotonic() + 45.0
+    while True:
+        concurrent_succeeded = pgcron_client.conn.execute(
+            """
+            select exists (
+              select 1
+              from cron.job_run_details
+              where command ilike 'alter table absurd.% detach partition absurd.% concurrently'
+                and status = 'succeeded'
+            )
+            """
+        ).fetchone()[0]
+        if concurrent_succeeded:
+            break
+        if time.monotonic() >= deadline:
+            raise AssertionError("concurrent detach job did not succeed")
+        pgcron_postgres_container.advance_system_time(minutes=2)
+        time.sleep(1.0)
+
+
 def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
     queue = "cron-drop-live"
 

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -13,8 +13,18 @@ def _wait_until(predicate, *, timeout=30.0, interval=0.25, message="condition no
     raise AssertionError(message)
 
 
+def _register_queue_cleanup(request, client, queue):
+    def _cleanup():
+        try:
+            client.drop_queue(queue)
+        except Exception:
+            pass
+
+    request.addfinalizer(_cleanup)
+
+
 def test_pgcron_time_jump_executes_detach_and_drop_jobs(
-    pgcron_client, pgcron_postgres_container
+    pgcron_client, pgcron_postgres_container, request
 ):
     queue = "cron-live-detach"
     base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
@@ -22,6 +32,7 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
     pgcron_postgres_container.set_system_time(base)
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
     pgcron_client.conn.execute(
         "select absurd.set_queue_policy(%s, %s::jsonb)",
         (queue, '{"detach_mode": "empty", "detach_min_age": "0 days"}'),
@@ -80,7 +91,7 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
             """
             select status, return_message
             from cron.job_run_details
-            where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
+            where command ilike 'alter table absurd.% detach partition absurd.%'
             order by runid desc
             limit 1
             """,
@@ -102,33 +113,42 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
             (
                 row := pgcron_client.conn.execute(
                     """
-                select status
-                from cron.job_run_details
-                where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
-                order by runid desc
-                limit 1
-                """,
+                    select status
+                    from cron.job_run_details
+                    where command ilike %s
+                      and command like %s
+                    order by runid desc
+                    limit 1
+                    """,
+                    (
+                        "alter table absurd.% detach partition absurd.%",
+                        f"%{partition_table}%",
+                    ),
                 ).fetchone()
             )
             is not None
             and row[0] != "running"
         ),
         timeout=20.0,
-        message="detach job did not finish",
+        message="target detach job did not finish",
     )
 
-    detach_row = pgcron_client.conn.execute(
+    target_detach_succeeded = pgcron_client.conn.execute(
         """
-        select status, return_message
-        from cron.job_run_details
-        where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
-        order by runid desc
-        limit 1
+        select exists (
+          select 1
+          from cron.job_run_details
+          where command ilike %s
+            and command like %s
+            and status = 'succeeded'
+        )
         """,
-    ).fetchone()
-    assert detach_row is not None
-    assert detach_row[0] == "failed"
-    assert "cannot be executed from a function" in (detach_row[1] or "")
+        (
+            "alter table absurd.% detach partition absurd.%",
+            f"%{partition_table}%",
+        ),
+    ).fetchone()[0]
+    assert target_detach_succeeded
 
     drop_ran = pgcron_client.conn.execute(
         """
@@ -141,21 +161,28 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(
     ).fetchone()[0]
     assert drop_ran
 
-    # Since DETACH ... CONCURRENTLY fails under pg_cron execution context,
-    # the source partition is still present.
-    assert (
-        pgcron_client.conn.execute(
-            "select to_regclass(%s)",
-            (f"absurd.{partition_table}",),
-        ).fetchone()[0]
-        is not None
-    )
+    drop_deadline = time.monotonic() + 45.0
+    while True:
+        dropped = (
+            pgcron_client.conn.execute(
+                "select to_regclass(%s)",
+                (f"absurd.{partition_table}",),
+            ).fetchone()[0]
+            is None
+        )
+        if dropped:
+            break
+        if time.monotonic() >= drop_deadline:
+            raise AssertionError("partition table was not dropped")
+        pgcron_postgres_container.advance_system_time(minutes=2)
+        time.sleep(1.0)
 
 
-def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
+def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client, request):
     queue = "cron-drop-live"
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
     pgcron_client.conn.execute(
         """
         select *
@@ -193,6 +220,7 @@ def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
 def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
     pgcron_client,
     pgcron_postgres_container,
+    request,
 ):
     queue = "cron-cleanup-live"
     base = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
@@ -200,6 +228,7 @@ def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
     pgcron_postgres_container.set_system_time(base)
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
     pgcron_client.conn.execute(
         "select absurd.set_queue_policy(%s, %s::jsonb)",
         (queue, '{"cleanup_ttl": "3600 seconds", "cleanup_limit": 100}'),
@@ -254,12 +283,14 @@ def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
 def test_partitioned_idempotency_key_survives_week_boundary_with_real_time(
     pgcron_client,
     pgcron_postgres_container,
+    request,
 ):
     queue = "cron-idempotency-live"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
 
     first = pgcron_client.spawn_task(
         queue,
@@ -294,6 +325,7 @@ def test_partitioned_idempotency_key_survives_week_boundary_with_real_time(
 def test_partitioned_events_resume_across_week_boundary_with_real_time(
     pgcron_client,
     pgcron_postgres_container,
+    request,
 ):
     queue = "cron-events-live"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
@@ -302,6 +334,7 @@ def test_partitioned_events_resume_across_week_boundary_with_real_time(
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
 
     spawned = pgcron_client.spawn_task(queue, "waiter", {"step": 1})
     claim = pgcron_client.claim_tasks(queue)[0]
@@ -338,12 +371,14 @@ def test_partitioned_events_resume_across_week_boundary_with_real_time(
 def test_ensure_partitions_and_default_partition_fallback_with_real_time(
     pgcron_client,
     pgcron_postgres_container,
+    request,
 ):
     queue = "cron-default-live"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
 
     # C1: ensure_partitions can precreate future week partitions.
     pgcron_client.conn.execute(
@@ -395,12 +430,14 @@ def test_ensure_partitions_and_default_partition_fallback_with_real_time(
 def test_tasks_in_default_partition_are_claimable_and_completable(
     pgcron_client,
     pgcron_postgres_container,
+    request,
 ):
     queue = "cron-default-taskflow"
     base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
 
     pgcron_postgres_container.set_system_time(base)
     pgcron_client.create_queue(queue, storage_mode="partitioned")
+    _register_queue_cleanup(request, pgcron_client, queue)
 
     # Keep partition window narrow so a far-future task lands in default.
     pgcron_client.conn.execute(

--- a/tests/test_cron_pgcron_e2e.py
+++ b/tests/test_cron_pgcron_e2e.py
@@ -1,4 +1,7 @@
 import time
+from datetime import datetime, timedelta, timezone
+
+from psycopg import sql
 
 
 def _wait_until(predicate, *, timeout=30.0, interval=0.25, message="condition not met"):
@@ -12,6 +15,9 @@ def _wait_until(predicate, *, timeout=30.0, interval=0.25, message="condition no
 
 def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_postgres_container):
     queue = "cron-live-detach"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+
+    pgcron_postgres_container.set_system_time(base)
 
     pgcron_client.create_queue(queue, storage_mode="partitioned")
     pgcron_client.conn.execute(
@@ -36,6 +42,8 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_po
             "1 second",
         ),
     )
+
+    pgcron_postgres_container.advance_system_time(days=120)
 
     candidate_row = pgcron_client.conn.execute(
         """
@@ -86,6 +94,24 @@ def test_pgcron_time_jump_executes_detach_and_drop_jobs(pgcron_client, pgcron_po
         # time.
         pgcron_postgres_container.advance_system_time(minutes=2)
         time.sleep(1.0)
+
+    _wait_until(
+        lambda: (
+            (row := pgcron_client.conn.execute(
+                """
+                select status
+                from cron.job_run_details
+                where command ilike 'alter table absurd.% detach partition absurd.% concurrently%'
+                order by runid desc
+                limit 1
+                """,
+            ).fetchone())
+            is not None
+            and row[0] != "running"
+        ),
+        timeout=20.0,
+        message="detach job did not finish",
+    )
 
     detach_row = pgcron_client.conn.execute(
         """
@@ -156,3 +182,252 @@ def test_drop_queue_removes_queue_scoped_pgcron_jobs(pgcron_client):
         (f"absurd%{scope}%",),
     ).fetchone()[0]
     assert remaining == 0
+
+
+def test_pgcron_cleanup_all_queues_cleans_old_rows_only(
+    pgcron_client,
+    pgcron_postgres_container,
+):
+    queue = "cron-cleanup-live"
+    base = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
+
+    pgcron_postgres_container.set_system_time(base)
+
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+    pgcron_client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"cleanup_ttl": "3600 seconds", "cleanup_limit": 100}'),
+    )
+
+    old_spawn = pgcron_client.spawn_task(queue, "cleanup-old", {"kind": "old"})
+    old_claim = pgcron_client.claim_tasks(queue)[0]
+    pgcron_client.complete_run(queue, old_claim["run_id"], {"ok": True})
+    pgcron_client.emit_event(queue, "cleanup-old-event", {"kind": "old"})
+
+    pgcron_postgres_container.advance_system_time(hours=3)
+
+    live_spawn = pgcron_client.spawn_task(queue, "cleanup-live", {"kind": "live"})
+    pgcron_client.emit_event(queue, "cleanup-live-event", {"kind": "live"})
+
+    assert pgcron_client.count_tasks(queue) == 2
+    assert pgcron_client.count_events(queue) == 2
+
+    pgcron_client.conn.execute(
+        """
+        select *
+        from absurd.enable_cron(%s, %s, %s, %s)
+        """,
+        (queue, "0 0 1 1 *", "1 second", "0 0 1 1 *"),
+    )
+
+    _wait_until(
+        lambda: pgcron_client.count_tasks(queue) == 1
+        and pgcron_client.count_events(queue) == 1,
+        timeout=20.0,
+        message="cleanup cron job did not remove expected old rows",
+    )
+
+    assert pgcron_client.get_task(queue, old_spawn.task_id) is None
+    assert pgcron_client.get_task(queue, live_spawn.task_id) is not None
+
+    cleanup_job_ran = pgcron_client.conn.execute(
+        """
+        select exists (
+          select 1
+          from cron.job_run_details
+          where command like 'select * from absurd.cleanup_all_queues(%'
+            and status = 'succeeded'
+        )
+        """
+    ).fetchone()[0]
+    assert cleanup_job_ran
+
+
+def test_partitioned_idempotency_key_survives_week_boundary_with_real_time(
+    pgcron_client,
+    pgcron_postgres_container,
+):
+    queue = "cron-idempotency-live"
+    base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
+
+    pgcron_postgres_container.set_system_time(base)
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+
+    first = pgcron_client.spawn_task(
+        queue,
+        "idem",
+        {"n": 1},
+        {"idempotency_key": "cross-week-idem"},
+    )
+
+    pgcron_postgres_container.advance_system_time(days=8)
+
+    second = pgcron_client.spawn_task(
+        queue,
+        "idem",
+        {"n": 2},
+        {"idempotency_key": "cross-week-idem"},
+    )
+
+    assert second.task_id == first.task_id
+    assert second.run_id == first.run_id
+    assert pgcron_client.count_tasks(queue) == 1
+
+    row = pgcron_client.conn.execute(
+        sql.SQL("select task_id from absurd.{tbl} where idempotency_key = %s").format(
+            tbl=sql.Identifier(f"i_{queue}")
+        ),
+        ("cross-week-idem",),
+    ).fetchone()
+    assert row is not None
+    assert str(row[0]) == str(first.task_id)
+
+
+def test_partitioned_events_resume_across_week_boundary_with_real_time(
+    pgcron_client,
+    pgcron_postgres_container,
+):
+    queue = "cron-events-live"
+    base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
+    event_name = "cross-week-event"
+    payload = {"ok": True}
+
+    pgcron_postgres_container.set_system_time(base)
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+
+    spawned = pgcron_client.spawn_task(queue, "waiter", {"step": 1})
+    claim = pgcron_client.claim_tasks(queue)[0]
+    assert claim["run_id"] == spawned.run_id
+
+    first_wait = pgcron_client.await_event(
+        queue,
+        spawned.task_id,
+        spawned.run_id,
+        "wait",
+        event_name,
+        None,
+    )
+    assert first_wait["should_suspend"] is True
+
+    pgcron_postgres_container.advance_system_time(days=8)
+    pgcron_client.emit_event(queue, event_name, payload)
+
+    reclaimed = pgcron_client.claim_tasks(queue)[0]
+    assert reclaimed["run_id"] == spawned.run_id
+
+    resumed = pgcron_client.await_event(
+        queue,
+        spawned.task_id,
+        spawned.run_id,
+        "wait",
+        event_name,
+        None,
+    )
+    assert resumed["should_suspend"] is False
+    assert resumed["payload"] == payload
+
+
+def test_ensure_partitions_and_default_partition_fallback_with_real_time(
+    pgcron_client,
+    pgcron_postgres_container,
+):
+    queue = "cron-default-live"
+    base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
+
+    pgcron_postgres_container.set_system_time(base)
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+
+    # C1: ensure_partitions can precreate future week partitions.
+    pgcron_client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"partition_lookahead": "70 days"}'),
+    )
+    pgcron_client.conn.execute("select absurd.ensure_partitions(%s)", (queue,))
+
+    future_tag = pgcron_client.conn.execute(
+        "select absurd.partition_week_tag(%s)",
+        (base + timedelta(days=63),),
+    ).fetchone()[0]
+
+    for prefix in ["t", "r", "c", "w"]:
+        rel = pgcron_client.conn.execute(
+            "select to_regclass(%s)",
+            (f"absurd.{prefix}_{queue}_{future_tag}",),
+        ).fetchone()[0]
+        assert rel is not None
+
+    # C2: out-of-window rows should route into default partitions.
+    pgcron_client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"partition_lookahead": "7 days", "partition_lookback": "1 day"}'),
+    )
+    pgcron_client.conn.execute("select absurd.ensure_partitions(%s)", (queue,))
+
+    pgcron_postgres_container.advance_system_time(days=240)
+
+    spawned = pgcron_client.spawn_task(queue, "default-route", {"kind": "late"})
+
+    task_partition = pgcron_client.conn.execute(
+        sql.SQL(
+            "select tableoid::regclass::text from absurd.{tbl} where task_id = %s"
+        ).format(tbl=sql.Identifier(f"t_{queue}")),
+        (spawned.task_id,),
+    ).fetchone()[0]
+    run_partition = pgcron_client.conn.execute(
+        sql.SQL(
+            "select tableoid::regclass::text from absurd.{tbl} where run_id = %s"
+        ).format(tbl=sql.Identifier(f"r_{queue}")),
+        (spawned.run_id,),
+    ).fetchone()[0]
+
+    assert task_partition.replace('"', '') == f"absurd.t_{queue}_d"
+    assert run_partition.replace('"', '') == f"absurd.r_{queue}_d"
+
+
+def test_tasks_in_default_partition_are_claimable_and_completable(
+    pgcron_client,
+    pgcron_postgres_container,
+):
+    queue = "cron-default-taskflow"
+    base = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
+
+    pgcron_postgres_container.set_system_time(base)
+    pgcron_client.create_queue(queue, storage_mode="partitioned")
+
+    # Keep partition window narrow so a far-future task lands in default.
+    pgcron_client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"partition_lookahead": "7 days", "partition_lookback": "1 day"}'),
+    )
+    pgcron_client.conn.execute("select absurd.ensure_partitions(%s)", (queue,))
+
+    pgcron_postgres_container.advance_system_time(days=240)
+
+    spawned = pgcron_client.spawn_task(queue, "default-task", {"kind": "late"})
+
+    task_partition = pgcron_client.conn.execute(
+        sql.SQL(
+            "select tableoid::regclass::text from absurd.{tbl} where task_id = %s"
+        ).format(tbl=sql.Identifier(f"t_{queue}")),
+        (spawned.task_id,),
+    ).fetchone()[0]
+    run_partition = pgcron_client.conn.execute(
+        sql.SQL(
+            "select tableoid::regclass::text from absurd.{tbl} where run_id = %s"
+        ).format(tbl=sql.Identifier(f"r_{queue}")),
+        (spawned.run_id,),
+    ).fetchone()[0]
+
+    assert task_partition.replace('"', '') == f"absurd.t_{queue}_d"
+    assert run_partition.replace('"', '') == f"absurd.r_{queue}_d"
+
+    claim = pgcron_client.claim_tasks(queue, worker="default-worker")
+    assert claim
+    assert claim[0]["run_id"] == spawned.run_id
+
+    pgcron_client.complete_run(queue, spawned.run_id, {"ok": True})
+
+    task_row = pgcron_client.get_task(queue, spawned.task_id)
+    run_row = pgcron_client.get_run(queue, spawned.run_id)
+    assert task_row is not None and task_row["state"] == "completed"
+    assert run_row is not None and run_row["state"] == "completed"

--- a/tests/test_idempotent_spawn.py
+++ b/tests/test_idempotent_spawn.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 
 def test_spawn_with_idempotency_key_creates_task(client):
@@ -158,3 +158,68 @@ def test_idempotency_key_works_across_different_task_names(client):
 
     task = client.get_task(queue, first.task_id)
     assert task["task_name"] == "task-a"
+
+
+def test_idempotency_key_is_released_after_task_cleanup(client):
+    queue = "idempotent-cleanup"
+    client.create_queue(queue)
+
+    base = datetime(2024, 5, 7, 10, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+
+    first = client.spawn_task(
+        queue,
+        "my-task",
+        {"value": 1},
+        {"idempotency_key": "cleanup-key"},
+    )
+
+    claim = client.claim_tasks(queue, worker="worker")[0]
+    client.complete_run(queue, claim["run_id"], {"result": "done"})
+
+    client.set_fake_now(base + timedelta(days=2))
+    deleted = client.cleanup_tasks(queue, ttl_seconds=3600, limit=10)
+    assert deleted == 1
+
+    second = client.spawn_task(
+        queue,
+        "my-task",
+        {"value": 2},
+        {"idempotency_key": "cleanup-key"},
+    )
+
+    assert second.task_id != first.task_id
+    assert second.attempt == 1
+
+
+def test_partitioned_queue_uses_idempotency_registry(client):
+    queue = "idempotent_partitioned"
+    client.create_queue(queue, storage_mode="partitioned")
+
+    base = datetime(2024, 5, 8, 10, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+
+    first = client.spawn_task(
+        queue,
+        "my-task",
+        {"value": 1},
+        {"idempotency_key": "registry-key"},
+    )
+
+    second = client.spawn_task(
+        queue,
+        "my-task",
+        {"value": 2},
+        {"idempotency_key": "registry-key"},
+    )
+
+    assert second.task_id == first.task_id
+    assert second.run_id == first.run_id
+    assert second.attempt == first.attempt
+
+    row = client.conn.execute(
+        "select task_id from absurd.i_idempotent_partitioned where idempotency_key = %s",
+        ("registry-key",),
+    ).fetchone()
+    assert row is not None
+    assert str(row[0]) == str(first.task_id)

--- a/tests/test_partition_detach.py
+++ b/tests/test_partition_detach.py
@@ -25,7 +25,7 @@ def test_list_detach_candidates_respects_detach_policy(client):
 
     rows = client.conn.execute(
         """
-        select queue_name, parent_table, partition_table, detach_sql, drop_sql
+        select queue_name, parent_table, partition_table
         from absurd.list_detach_candidates(%s)
         order by partition_table
         """,
@@ -36,12 +36,9 @@ def test_list_detach_candidates_respects_detach_policy(client):
     for row in rows:
         assert row[0] == queue
         assert row[2].endswith("_d") is False
-        assert "detach partition" in row[3].lower()
-        assert "concurrently" not in row[3].lower()
-        assert row[4].lower().startswith("drop table if exists absurd.")
 
 
-def test_list_detach_candidates_uses_concurrently_without_default_partition(client):
+def test_list_detach_candidates_with_default_partition_disabled(client):
     queue = "detach-policy-concurrent"
     base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
 
@@ -58,7 +55,7 @@ def test_list_detach_candidates_uses_concurrently_without_default_partition(clie
     client.set_fake_now(base + timedelta(days=120))
     rows = client.conn.execute(
         """
-        select partition_table, detach_sql
+        select queue_name, parent_table, partition_table
         from absurd.list_detach_candidates(%s)
         order by partition_table
         """,
@@ -66,7 +63,7 @@ def test_list_detach_candidates_uses_concurrently_without_default_partition(clie
     ).fetchall()
 
     assert rows
-    assert all("concurrently" in row[1].lower() for row in rows)
+    assert all(row[0] == queue for row in rows)
 
 
 def test_list_detach_candidates_skips_non_empty_partitions(client):

--- a/tests/test_partition_detach.py
+++ b/tests/test_partition_detach.py
@@ -41,6 +41,34 @@ def test_list_detach_candidates_respects_detach_policy(client):
         assert row[4].lower().startswith("drop table if exists absurd.")
 
 
+def test_list_detach_candidates_uses_concurrently_without_default_partition(client):
+    queue = "detach-policy-concurrent"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (
+            queue,
+            '{"detach_mode": "empty", "detach_min_age": "30 days", "default_partition": "disabled"}',
+        ),
+    )
+
+    client.set_fake_now(base + timedelta(days=120))
+    rows = client.conn.execute(
+        """
+        select partition_table, detach_sql
+        from absurd.list_detach_candidates(%s)
+        order by partition_table
+        """,
+        (queue,),
+    ).fetchall()
+
+    assert rows
+    assert all("concurrently" in row[1].lower() for row in rows)
+
+
 def test_list_detach_candidates_skips_non_empty_partitions(client):
     queue = "detach-nonempty"
     base = datetime(2024, 4, 8, 9, 0, tzinfo=timezone.utc)

--- a/tests/test_partition_detach.py
+++ b/tests/test_partition_detach.py
@@ -37,7 +37,7 @@ def test_list_detach_candidates_respects_detach_policy(client):
         assert row[0] == queue
         assert row[2].endswith("_d") is False
         assert "detach partition" in row[3].lower()
-        assert "concurrently" in row[3].lower()
+        assert "concurrently" not in row[3].lower()
         assert row[4].lower().startswith("drop table if exists absurd.")
 
 

--- a/tests/test_partition_detach.py
+++ b/tests/test_partition_detach.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta, timezone
+
+
+def test_list_detach_candidates_respects_detach_policy(client):
+    queue = "detach-policy"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+
+    # Default policy does not emit any detach candidates.
+    no_candidates = client.conn.execute(
+        "select * from absurd.list_detach_candidates(%s)",
+        (queue,),
+    ).fetchall()
+    assert no_candidates == []
+
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"detach_mode": "empty", "detach_min_age": "30 days"}'),
+    )
+
+    # Move time forward so old pre-created partitions become detachable.
+    client.set_fake_now(base + timedelta(days=120))
+
+    rows = client.conn.execute(
+        """
+        select queue_name, parent_table, partition_table, detach_sql, drop_sql
+        from absurd.list_detach_candidates(%s)
+        order by partition_table
+        """,
+        (queue,),
+    ).fetchall()
+
+    assert rows
+    for row in rows:
+        assert row[0] == queue
+        assert row[2].endswith("_d") is False
+        assert "detach partition" in row[3].lower()
+        assert "concurrently" in row[3].lower()
+        assert row[4].lower().startswith("drop table if exists absurd.")
+
+
+def test_list_detach_candidates_skips_non_empty_partitions(client):
+    queue = "detach-nonempty"
+    base = datetime(2024, 4, 8, 9, 0, tzinfo=timezone.utc)
+
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+
+    current_tag = client.conn.execute(
+        "select absurd.partition_week_tag(%s)",
+        (base,),
+    ).fetchone()[0]
+
+    client.spawn_task(queue, "keep-alive", {"x": 1})
+
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"detach_mode": "empty", "detach_min_age": "0 days"}'),
+    )
+
+    client.set_fake_now(base + timedelta(days=60))
+
+    rows = client.conn.execute(
+        """
+        select parent_table, partition_table
+        from absurd.list_detach_candidates(%s)
+        where parent_table in (%s, %s)
+        """,
+        (queue, f"t_{queue}", f"r_{queue}"),
+    ).fetchall()
+
+    partition_names = {row[1] for row in rows}
+
+    # The partition holding live task/run rows is not eligible while non-empty.
+    assert f"t_{queue}_{current_tag}" not in partition_names
+    assert f"r_{queue}_{current_tag}" not in partition_names

--- a/tests/test_partition_utils.py
+++ b/tests/test_partition_utils.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timezone
+
+
+def test_uuidv7_timestamp_extracts_timestamp(client):
+    frozen = datetime(2024, 4, 1, 10, 20, 30, 123000, tzinfo=timezone.utc)
+    client.set_fake_now(frozen)
+
+    row = client.conn.execute(
+        "select absurd.uuidv7_timestamp(absurd.portable_uuidv7())"
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == frozen
+
+
+def test_uuidv7_timestamp_returns_null_for_non_v7(client):
+    row = client.conn.execute(
+        "select absurd.uuidv7_timestamp(uuid_generate_v4())"
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] is None
+
+
+def test_uuidv7_floor_rounds_down_to_millisecond(client):
+    ts = datetime(2024, 4, 1, 10, 20, 30, 123789, tzinfo=timezone.utc)
+    row = client.conn.execute(
+        "select absurd.uuidv7_timestamp(absurd.uuidv7_floor(%s))",
+        (ts,),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == datetime(2024, 4, 1, 10, 20, 30, 123000, tzinfo=timezone.utc)
+
+
+def test_uuidv7_floor_is_lower_bound_for_same_millisecond(client):
+    frozen = datetime(2024, 4, 1, 10, 20, 30, 123456, tzinfo=timezone.utc)
+    client.set_fake_now(frozen)
+
+    row = client.conn.execute(
+        """
+        with sample as (
+          select absurd.portable_uuidv7() as u
+        )
+        select
+          u >= absurd.uuidv7_floor(%s) as ge_lo,
+          u < absurd.uuidv7_floor(%s + interval '1 millisecond') as lt_hi
+        from sample
+        """,
+        (frozen, frozen),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] is True
+    assert row[1] is True
+
+
+def test_week_bucket_utc_snaps_to_monday_start(client):
+    row = client.conn.execute(
+        "select absurd.week_bucket_utc(%s)",
+        (datetime(2024, 4, 3, 15, 30, tzinfo=timezone.utc),),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == datetime(2024, 4, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_partition_week_tag_uses_iso_year_at_start_boundary(client):
+    row = client.conn.execute(
+        "select absurd.partition_week_tag(%s)",
+        (datetime(2021, 1, 1, 12, 0, tzinfo=timezone.utc),),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == "053"
+    assert row[0][1:] != "00"
+
+
+def test_partition_week_tag_uses_iso_year_at_end_boundary(client):
+    row = client.conn.execute(
+        "select absurd.partition_week_tag(%s)",
+        (datetime(2024, 12, 31, 12, 0, tzinfo=timezone.utc),),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == "501"

--- a/tests/test_queue_management.py
+++ b/tests/test_queue_management.py
@@ -77,6 +77,7 @@ def test_queue_storage_mode_defaults_to_unpartitioned(client):
         """
         select
           storage_mode,
+          default_partition,
           partition_lookahead,
           partition_lookback,
           cleanup_ttl,
@@ -90,12 +91,13 @@ def test_queue_storage_mode_defaults_to_unpartitioned(client):
     ).fetchone()
     assert row is not None
     assert row[0] == "unpartitioned"
-    assert row[1] == timedelta(days=28)
-    assert row[2] == timedelta(days=1)
-    assert row[3] == timedelta(days=30)
-    assert row[4] == 1000
-    assert row[5] == "none"
-    assert row[6] == timedelta(days=30)
+    assert row[1] == "enabled"
+    assert row[2] == timedelta(days=28)
+    assert row[3] == timedelta(days=1)
+    assert row[4] == timedelta(days=30)
+    assert row[5] == 1000
+    assert row[6] == "none"
+    assert row[7] == timedelta(days=30)
 
     has_idempotency_table = client.conn.execute(
         """
@@ -250,13 +252,14 @@ def test_queue_policy_can_be_updated(client):
         """,
         (
             queue,
-            '{"partition_lookahead":"35 days","partition_lookback":"2 days","cleanup_ttl":"12345 seconds","cleanup_limit":77,"detach_mode":"empty","detach_min_age":"45 days"}',
+            '{"default_partition":"disabled","partition_lookahead":"35 days","partition_lookback":"2 days","cleanup_ttl":"12345 seconds","cleanup_limit":77,"detach_mode":"empty","detach_min_age":"45 days"}',
         ),
     )
 
     row = client.conn.execute(
         """
         select
+          default_partition,
           partition_lookahead,
           partition_lookback,
           cleanup_ttl,
@@ -269,12 +272,13 @@ def test_queue_policy_can_be_updated(client):
     ).fetchone()
 
     assert row is not None
-    assert row[0] == timedelta(days=35)
-    assert row[1] == timedelta(days=2)
-    assert row[2] == timedelta(seconds=12345)
-    assert row[3] == 77
-    assert row[4] == "empty"
-    assert row[5] == timedelta(days=45)
+    assert row[0] == "disabled"
+    assert row[1] == timedelta(days=35)
+    assert row[2] == timedelta(days=2)
+    assert row[3] == timedelta(seconds=12345)
+    assert row[4] == 77
+    assert row[5] == "empty"
+    assert row[6] == timedelta(days=45)
 
 
 def test_set_queue_policy_rejects_unknown_keys(client):
@@ -297,6 +301,96 @@ def test_set_queue_policy_rejects_invalid_values(client):
             "select absurd.set_queue_policy(%s, %s::jsonb)",
             (queue, '{"cleanup_limit": 0}'),
         )
+    client.conn.rollback()
+
+    with pytest.raises(Exception):
+        client.conn.execute(
+            "select absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, '{"default_partition": "disabled"}'),
+        )
+    client.conn.rollback()
+
+    queue_partitioned = "mode-policy-invalid-part"
+    client.create_queue(queue_partitioned, storage_mode="partitioned")
+
+    with pytest.raises(Exception):
+        client.conn.execute(
+            "select absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue_partitioned, '{"default_partition": "oops"}'),
+        )
+
+
+def test_partitioned_queue_can_disable_and_reenable_default_partitions(client):
+    queue = "mode-default-toggle"
+    client.create_queue(queue, storage_mode="partitioned")
+
+    for prefix in ["t", "r", "c", "w"]:
+        assert _get_relkind(client.conn, f"{prefix}_{queue}_d") == "r"
+
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"default_partition": "disabled"}'),
+    )
+
+    row = client.conn.execute(
+        "select default_partition from absurd.get_queue_policy(%s)",
+        (queue,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "disabled"
+
+    for prefix in ["t", "r", "c", "w"]:
+        assert _get_relkind(client.conn, f"{prefix}_{queue}_d") is None
+
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"default_partition": "enabled"}'),
+    )
+
+    row = client.conn.execute(
+        "select default_partition from absurd.get_queue_policy(%s)",
+        (queue,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "enabled"
+
+    for prefix in ["t", "r", "c", "w"]:
+        assert _get_relkind(client.conn, f"{prefix}_{queue}_d") == "r"
+
+
+def test_disabling_default_partitions_requires_empty_default_partitions(client):
+    queue = "mode-default-disable-nonempty"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+
+    # Move well beyond the initially pre-created window so writes land in _d.
+    client.set_fake_now(base + timedelta(days=120))
+    client.spawn_task(queue, "out-of-window", {"x": 1})
+
+    with pytest.raises(Exception):
+        client.conn.execute(
+            "select absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, '{"default_partition": "disabled"}'),
+        )
+
+
+def test_partitioned_queue_without_default_partition_fails_out_of_window_insert(client):
+    queue = "mode-default-disabled-insert"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+
+    client.conn.execute(
+        "select absurd.set_queue_policy(%s, %s::jsonb)",
+        (queue, '{"default_partition": "disabled"}'),
+    )
+
+    # No ensure_partitions call after this time jump means no matching weekly
+    # partition should exist and, without _d, inserts must fail.
+    client.set_fake_now(base + timedelta(days=120))
+    with pytest.raises(Exception):
+        client.spawn_task(queue, "should-fail", {"x": 1})
 
 
 def test_create_queue_rejects_existing_partitioned_queue_in_default_mode(client):

--- a/tests/test_queue_management.py
+++ b/tests/test_queue_management.py
@@ -4,6 +4,20 @@ from psycopg import sql
 import pytest
 
 
+def _get_relkind(conn, relname):
+    row = conn.execute(
+        """
+        select c.relkind
+        from pg_class c
+        join pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'absurd'
+          and c.relname = %s
+        """,
+        (relname,),
+    ).fetchone()
+    return row[0] if row else None
+
+
 def test_cleanup_tasks_and_events(client):
     queue = "cleanup"
     client.create_queue(queue)
@@ -53,6 +67,185 @@ def test_queue_management_round_trip(client):
 
     client.drop_queue("main")
     assert client.list_queues() == []
+
+
+def test_queue_storage_mode_defaults_to_unpartitioned(client):
+    queue = "mode-default"
+    client.create_queue(queue)
+
+    row = client.conn.execute(
+        "select storage_mode from absurd.queues where queue_name = %s",
+        (queue,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "unpartitioned"
+
+    has_idempotency_table = client.conn.execute(
+        """
+        select 1
+        from pg_tables
+        where schemaname = 'absurd'
+          and tablename = %s
+        """,
+        (f"i_{queue}",),
+    ).fetchone()
+    assert has_idempotency_table is None
+
+
+def test_partitioned_queue_creates_idempotency_registry_table(client):
+    queue = "mode-partitioned"
+    client.create_queue(queue, storage_mode="partitioned")
+
+    row = client.conn.execute(
+        "select storage_mode from absurd.queues where queue_name = %s",
+        (queue,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "partitioned"
+
+    has_idempotency_table = client.conn.execute(
+        """
+        select 1
+        from pg_tables
+        where schemaname = 'absurd'
+          and tablename = %s
+        """,
+        (f"i_{queue}",),
+    ).fetchone()
+    assert has_idempotency_table is not None
+
+
+def test_partitioned_queue_creates_partitioned_parents_and_week_partitions(client):
+    queue = "mode-partition-ddl"
+    client.create_queue(queue, storage_mode="partitioned")
+
+    # Parent tables should be declarative partitioned tables.
+    for prefix in ["t", "r", "c", "w"]:
+        assert _get_relkind(client.conn, f"{prefix}_{queue}") == "p"
+
+    # Events stay unpartitioned for now.
+    assert _get_relkind(client.conn, f"e_{queue}") == "r"
+
+    row = client.conn.execute(
+        """
+        select
+          absurd.partition_week_tag(absurd.current_time()),
+          absurd.uuidv7_floor(absurd.week_bucket_utc(absurd.current_time())),
+          absurd.uuidv7_floor(absurd.week_bucket_utc(absurd.current_time()) + interval '7 days')
+        """
+    ).fetchone()
+    assert row is not None
+    tag, lo, hi = row
+
+    for prefix in ["t", "r", "c", "w"]:
+        weekly_name = f"{prefix}_{queue}_{tag}"
+        default_name = f"{prefix}_{queue}_d"
+
+        weekly_bound = client.conn.execute(
+            """
+            select pg_get_expr(c.relpartbound, c.oid)
+            from pg_class c
+            join pg_namespace n on n.oid = c.relnamespace
+            where n.nspname = 'absurd'
+              and c.relname = %s
+            """,
+            (weekly_name,),
+        ).fetchone()
+        assert weekly_bound is not None
+        assert str(lo) in weekly_bound[0]
+        assert str(hi) in weekly_bound[0]
+
+        default_bound = client.conn.execute(
+            """
+            select pg_get_expr(c.relpartbound, c.oid)
+            from pg_class c
+            join pg_namespace n on n.oid = c.relnamespace
+            where n.nspname = 'absurd'
+              and c.relname = %s
+            """,
+            (default_name,),
+        ).fetchone()
+        assert default_bound is not None
+        assert default_bound[0] == "DEFAULT"
+
+
+def test_ensure_partitions_can_precreate_future_weeks(client):
+    queue = "mode-partition-future"
+    base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
+    future = base + timedelta(days=21)
+    client.set_fake_now(base)
+    client.create_queue(queue, storage_mode="partitioned")
+
+    future_tag_row = client.conn.execute(
+        "select absurd.partition_week_tag(%s)",
+        (future,),
+    ).fetchone()
+    assert future_tag_row is not None
+    future_tag = future_tag_row[0]
+
+    # Not created by initial queue setup yet.
+    assert _get_relkind(client.conn, f"t_{queue}_{future_tag}") is None
+
+    client.conn.execute("select absurd.ensure_partitions(%s, %s)", (queue, future))
+
+    for prefix in ["t", "r", "c", "w"]:
+        assert _get_relkind(client.conn, f"{prefix}_{queue}_{future_tag}") == "r"
+
+
+def test_partitioned_queue_creation_uses_skew_lookback_window(client):
+    queue = "mode-partition-skew"
+    boundary = datetime(2024, 4, 1, 0, 30, tzinfo=timezone.utc)
+    client.set_fake_now(boundary)
+    client.create_queue(queue, storage_mode="partitioned")
+
+    row = client.conn.execute(
+        """
+        select
+          absurd.partition_week_tag(absurd.current_time()),
+          absurd.partition_week_tag(absurd.current_time() - interval '1 day')
+        """
+    ).fetchone()
+    assert row is not None
+    current_tag, previous_tag = row
+    assert previous_tag != current_tag
+
+    for prefix in ["t", "r", "c", "w"]:
+        assert _get_relkind(client.conn, f"{prefix}_{queue}_{current_tag}") == "r"
+        assert _get_relkind(client.conn, f"{prefix}_{queue}_{previous_tag}") == "r"
+
+
+def test_create_queue_rejects_existing_partitioned_queue_in_default_mode(client):
+    queue = "mode-existing"
+    client.create_queue(queue, storage_mode="partitioned")
+
+    with pytest.raises(Exception):
+        client.create_queue(queue)
+
+
+def test_create_queue_with_partitioned_mode_is_idempotent(client):
+    queue = "mode-partitioned-idempotent"
+    client.create_queue(queue, storage_mode="partitioned")
+    client.create_queue(queue, storage_mode="partitioned")
+
+    row = client.conn.execute(
+        "select storage_mode from absurd.queues where queue_name = %s",
+        (queue,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "partitioned"
+
+
+def test_create_queue_rejects_storage_mode_mismatch(client):
+    queue = "mode-mismatch"
+    client.create_queue(queue)
+
+    with pytest.raises(Exception):
+        client.create_queue(queue, storage_mode="partitioned")
+
+
+def test_create_queue_rejects_unknown_storage_mode(client):
+    with pytest.raises(Exception):
+        client.create_queue("mode-unknown", storage_mode="timescale")
 
 
 def test_queue_name_validation_limits(client):

--- a/tests/test_queue_management.py
+++ b/tests/test_queue_management.py
@@ -79,7 +79,7 @@ def test_queue_storage_mode_defaults_to_unpartitioned(client):
           storage_mode,
           partition_lookahead,
           partition_lookback,
-          cleanup_ttl_seconds,
+          cleanup_ttl,
           cleanup_limit,
           detach_mode,
           detach_min_age
@@ -92,7 +92,7 @@ def test_queue_storage_mode_defaults_to_unpartitioned(client):
     assert row[0] == "unpartitioned"
     assert row[1] == timedelta(days=28)
     assert row[2] == timedelta(days=1)
-    assert row[3] == 30 * 86400
+    assert row[3] == timedelta(days=30)
     assert row[4] == 1000
     assert row[5] == "none"
     assert row[6] == timedelta(days=30)
@@ -250,7 +250,7 @@ def test_queue_policy_can_be_updated(client):
         """,
         (
             queue,
-            '{"partition_lookahead":"35 days","partition_lookback":"2 days","cleanup_ttl_seconds":12345,"cleanup_limit":77,"detach_mode":"empty","detach_min_age":"45 days"}',
+            '{"partition_lookahead":"35 days","partition_lookback":"2 days","cleanup_ttl":"12345 seconds","cleanup_limit":77,"detach_mode":"empty","detach_min_age":"45 days"}',
         ),
     )
 
@@ -259,7 +259,7 @@ def test_queue_policy_can_be_updated(client):
         select
           partition_lookahead,
           partition_lookback,
-          cleanup_ttl_seconds,
+          cleanup_ttl,
           cleanup_limit,
           detach_mode,
           detach_min_age
@@ -271,7 +271,7 @@ def test_queue_policy_can_be_updated(client):
     assert row is not None
     assert row[0] == timedelta(days=35)
     assert row[1] == timedelta(days=2)
-    assert row[2] == 12345
+    assert row[2] == timedelta(seconds=12345)
     assert row[3] == 77
     assert row[4] == "empty"
     assert row[5] == timedelta(days=45)

--- a/tests/test_queue_management.py
+++ b/tests/test_queue_management.py
@@ -74,11 +74,28 @@ def test_queue_storage_mode_defaults_to_unpartitioned(client):
     client.create_queue(queue)
 
     row = client.conn.execute(
-        "select storage_mode from absurd.queues where queue_name = %s",
+        """
+        select
+          storage_mode,
+          partition_lookahead,
+          partition_lookback,
+          cleanup_ttl_seconds,
+          cleanup_limit,
+          detach_mode,
+          detach_min_age
+        from absurd.queues
+        where queue_name = %s
+        """,
         (queue,),
     ).fetchone()
     assert row is not None
     assert row[0] == "unpartitioned"
+    assert row[1] == timedelta(days=28)
+    assert row[2] == timedelta(days=1)
+    assert row[3] == 30 * 86400
+    assert row[4] == 1000
+    assert row[5] == "none"
+    assert row[6] == timedelta(days=30)
 
     has_idempotency_table = client.conn.execute(
         """
@@ -172,7 +189,7 @@ def test_partitioned_queue_creates_partitioned_parents_and_week_partitions(clien
 def test_ensure_partitions_can_precreate_future_weeks(client):
     queue = "mode-partition-future"
     base = datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc)
-    future = base + timedelta(days=21)
+    future = base + timedelta(days=56)
     client.set_fake_now(base)
     client.create_queue(queue, storage_mode="partitioned")
 
@@ -186,7 +203,13 @@ def test_ensure_partitions_can_precreate_future_weeks(client):
     # Not created by initial queue setup yet.
     assert _get_relkind(client.conn, f"t_{queue}_{future_tag}") is None
 
-    client.conn.execute("select absurd.ensure_partitions(%s, %s)", (queue, future))
+    client.conn.execute(
+        """
+        select absurd.set_queue_policy(%s, %s::jsonb)
+        """,
+        (queue, '{"partition_lookahead": "60 days"}'),
+    )
+    client.conn.execute("select absurd.ensure_partitions(%s)", (queue,))
 
     for prefix in ["t", "r", "c", "w"]:
         assert _get_relkind(client.conn, f"{prefix}_{queue}_{future_tag}") == "r"
@@ -212,6 +235,68 @@ def test_partitioned_queue_creation_uses_skew_lookback_window(client):
     for prefix in ["t", "r", "c", "w"]:
         assert _get_relkind(client.conn, f"{prefix}_{queue}_{current_tag}") == "r"
         assert _get_relkind(client.conn, f"{prefix}_{queue}_{previous_tag}") == "r"
+
+
+def test_queue_policy_can_be_updated(client):
+    queue = "mode-policy"
+    client.create_queue(queue, storage_mode="partitioned")
+
+    client.conn.execute(
+        """
+        select absurd.set_queue_policy(
+          %s,
+          %s::jsonb
+        )
+        """,
+        (
+            queue,
+            '{"partition_lookahead":"35 days","partition_lookback":"2 days","cleanup_ttl_seconds":12345,"cleanup_limit":77,"detach_mode":"empty","detach_min_age":"45 days"}',
+        ),
+    )
+
+    row = client.conn.execute(
+        """
+        select
+          partition_lookahead,
+          partition_lookback,
+          cleanup_ttl_seconds,
+          cleanup_limit,
+          detach_mode,
+          detach_min_age
+        from absurd.get_queue_policy(%s)
+        """,
+        (queue,),
+    ).fetchone()
+
+    assert row is not None
+    assert row[0] == timedelta(days=35)
+    assert row[1] == timedelta(days=2)
+    assert row[2] == 12345
+    assert row[3] == 77
+    assert row[4] == "empty"
+    assert row[5] == timedelta(days=45)
+
+
+def test_set_queue_policy_rejects_unknown_keys(client):
+    queue = "mode-policy-unknown"
+    client.create_queue(queue)
+
+    with pytest.raises(Exception):
+        client.conn.execute(
+            "select absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, '{"not_a_policy": true}'),
+        )
+
+
+def test_set_queue_policy_rejects_invalid_values(client):
+    queue = "mode-policy-invalid"
+    client.create_queue(queue)
+
+    with pytest.raises(Exception):
+        client.conn.execute(
+            "select absurd.set_queue_policy(%s, %s::jsonb)",
+            (queue, '{"cleanup_limit": 0}'),
+        )
 
 
 def test_create_queue_rejects_existing_partitioned_queue_in_default_mode(client):

--- a/zensical.toml
+++ b/zensical.toml
@@ -29,6 +29,7 @@ nav = [
     {"Guide" = [
         {"Quickstart" = "quickstart.md"},
         {"Concepts" = "concepts.md"},
+        {"Storage" = "storage.md"},
         {"Database Setup and Migrations" = "database.md"},
         {"Cleanup and Retention" = "cleanup.md"},
         {"Working with Agents" = "agents.md"},


### PR DESCRIPTION
This PR implements support for partitioned queues in absurd.  The primary goal of partitioning is queue scalability as tables grow and to reduce the risk of VACUUM causing disruption.

The overall design is the following:

We have the following queue storage modes:

- `unpartitioned`: current table layout, current cleanup behavior.
- `partitioned` native Postgres partitions keyed by creation-time identity.

What we gain from the approach of this PR vs what the original design of the feature had in mind:

- avoids row rehoming when retention changes
- avoids rehome-related lock ordering complexity
- partitions only need to be provisioned around "now" (and can be easily pre-created by `pg_cron`)
- old partitions naturally become cold, so cleanup/vacuum pressure is localized

Partition routing is based on row identity created at insert time:

- UUIDv7 values encode creation time, which gives monotonic time locality.
- Partition key does not depend on retention/expiry.

For partitioned queues:

- `t_<queue>` / `c_<queue>` partitioned by `task_id`
- `r_<queue>` / `w_<queue>` partitioned by `run_id`

Each partitioned parent has a `DEFAULT` partition to prevent insert failures for non-UUIDv7 IDs
(should not happen) or any out-of-range values in case `pg_cron` failed to run (also ideally should not happen).

For this to work, we had to leave events unpartitioned and we had to add a new unpartitioned idempotency key table (`i_<queue>`).  However, since both events and idempotency keys are not commonly used, this is probably a reasonable trade-off.  For unpartitioned tables, we leave the idempotency key in the original task table.  For partitioned tables we store a redundant attribute of that record, the item puttency key for partition tables also in the task table. 

For cleanup and retention to work we had to insert the retention policies into the queue metadata tables.  This now means that there is a difference between old absurd and new absurd when it comes to cleanup.  We schedule one cron to create new partitions and we schedule another cron which finds partitions that can be safely detached and later dropped.  This works by scheduling a one-off cron for detachment as `pg_cron` can run `ALTER TABLE ... DETACH PARTITION ... CONCURRENTLY` when issued as raw top-level SQL but not from within a function (which starts a transaction).

Fixes #4 