### PR TITLE
fix: clarify sync worker concurrency behavior

### DIFF
--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -1625,7 +1625,17 @@ class Absurd(_AbsurdBase):
         batch_size: Optional[int] = None,
         poll_interval: float = 0.25,
     ) -> None:
-        """Start a synchronous worker that continuously polls for tasks"""
+        """Start a synchronous worker that continuously polls for tasks.
+
+        The synchronous worker executes tasks sequentially on a single connection.
+        Use ``AsyncAbsurd.start_worker`` for concurrent task execution.
+        """
+        if concurrency != 1:
+            raise ValueError(
+                "Absurd.start_worker() runs sequentially; "
+                "use concurrency=1 or AsyncAbsurd.start_worker() for concurrency"
+            )
+
         if worker_id is None:
             worker_id = f"{socket.gethostname()}:{os.getpid()}"
 

--- a/sdks/python/tests/test_absurd.py
+++ b/sdks/python/tests/test_absurd.py
@@ -45,6 +45,18 @@ def test_sync_worker_processes_task(conn, queue_name):
     assert seen == [{"user_id": 42}]
 
 
+def test_sync_worker_rejects_concurrency_above_one(conn, queue_name):
+    queue = queue_name("sync_single")
+    client = Absurd(conn, queue_name=queue)
+
+    try:
+        client.start_worker(concurrency=2)
+    except ValueError as exc:
+        assert "runs sequentially" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for concurrency > 1")
+
+
 def test_sync_worker_suspends_until_alarm(conn, queue_name):
     queue = queue_name("reminders")
     client = Absurd(conn, queue_name=queue)


### PR DESCRIPTION
Fixes #91

The sync worker always runs tasks sequentially on one connection, so passing concurrency > 1 is currently misleading. This change makes that explicit by rejecting non-1 values with a clear error and adds a regression test for it.

Greetings, saschabuehrle