### PR TITLE
Add extensions for admonitions

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -79,6 +79,10 @@ features = [
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
 
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.superfences]
+
 [project.theme.icon]
 logo = "material/cube-outline"
 repo = "fontawesome/brands/github"


### PR DESCRIPTION
This adds the necessary extensions to support admonitions, like the warning admonition [on the quickstart page](https://github.com/earendil-works/absurd/blob/main/docs/quickstart.md?plain=1#L592-L601). Currently, it's broken:

<img width="710" height="234" alt="image" src="https://github.com/user-attachments/assets/59e476f7-9f39-4e7a-8efb-b24fc0eb4c89" />

These three extensions are [recommended by zensical docs](https://zensical.org/docs/authoring/admonitions/#configuration-zensicaltoml) to support admonitions.

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
