### PR TITLE
Event Refactor

### DIFF
--- a/sdks/go/absurd/context.go
+++ b/sdks/go/absurd/context.go
@@ -30,11 +30,10 @@ type TaskContext struct {
 	eventRaw        json.RawMessage
 	onLeaseExtended func(time.Duration)
 
-	mu                                sync.Mutex
-	headersCache                      map[string]any
-	checkpointCache                   map[string]json.RawMessage
-	stepNameCounter                   map[string]int
-	awaitEventTimedOutColumnSupported *bool
+	mu              sync.Mutex
+	headersCache    map[string]any
+	checkpointCache map[string]json.RawMessage
+	stepNameCounter map[string]int
 }
 
 var errInvalidTaskHeaders = errors.New("absurd: invalid task headers")
@@ -157,58 +156,6 @@ func (t *TaskContext) nextCheckpointName(name string) string {
 		return name
 	}
 	return fmt.Sprintf("%s#%d", name, count)
-}
-
-func (t *TaskContext) getAwaitEventTimedOutColumnSupport() (bool, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.awaitEventTimedOutColumnSupported == nil {
-		return false, false
-	}
-	return *t.awaitEventTimedOutColumnSupported, true
-}
-
-func (t *TaskContext) setAwaitEventTimedOutColumnSupport(value bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	v := value
-	t.awaitEventTimedOutColumnSupported = &v
-}
-
-func (t *TaskContext) ensureAwaitEventTimedOutColumnSupport(ctx context.Context) (bool, error) {
-	if cached, ok := t.getAwaitEventTimedOutColumnSupport(); ok {
-		return cached, nil
-	}
-
-	row := t.client.db.QueryRowContext(ctx, `SELECT EXISTS (
-			SELECT 1
-			  FROM pg_catalog.pg_proc p
-			  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-			  JOIN LATERAL unnest(p.proargmodes, p.proargnames)
-			    WITH ORDINALITY AS out_args(mode, name, ord) ON true
-			 WHERE n.nspname = 'absurd'
-			   AND p.proname = 'await_event'
-			   AND out_args.mode IN ('o', 't')
-			   AND out_args.name = 'timed_out'
-		) AS supported`)
-
-	var supported bool
-	if err := row.Scan(&supported); err != nil {
-		return false, err
-	}
-	t.setAwaitEventTimedOutColumnSupport(supported)
-	return supported, nil
-}
-
-func (t *TaskContext) consumeLegacyAwaitEventTimeout(eventName string) bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.wakeEvent != eventName || t.eventRaw != nil {
-		return false
-	}
-	t.wakeEvent = ""
-	t.eventRaw = nil
-	return true
 }
 
 func (t *TaskContext) lookupCheckpoint(ctx context.Context, checkpointName string) (json.RawMessage, bool, error) {
@@ -435,15 +382,6 @@ func AwaitEvent[T any](ctx context.Context, eventName string, options ...AwaitEv
 		return value, nil
 	}
 
-	timedOutSupport, err := task.ensureAwaitEventTimedOutColumnSupport(ctx)
-	if err != nil {
-		return zero[T](), err
-	}
-
-	if !timedOutSupport && task.consumeLegacyAwaitEventTimeout(eventName) {
-		return zero[T](), newTimeoutError(`timed out waiting for event %q`, eventName)
-	}
-
 	var timeoutSeconds any = nil
 	if opts.Timeout > 0 {
 		timeoutSeconds = durationSeconds(opts.Timeout)
@@ -455,48 +393,50 @@ func AwaitEvent[T any](ctx context.Context, eventName string, options ...AwaitEv
 	var payload []byte
 	var timedOut bool
 
-	if timedOutSupport {
-		row := task.client.db.QueryRowContext(ctx, `SELECT should_suspend, payload, timed_out
+	rows, err := task.client.db.QueryContext(ctx, `SELECT *
         FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
-			task.queueName,
-			task.taskID,
-			task.runID,
-			checkpointName,
-			eventName,
-			timeoutSeconds,
-		)
-		if err := row.Scan(&shouldSuspend, &payload, &timedOut); err != nil {
-			return zero[T](), mapTaskStateError(err)
-		}
-	} else {
-		if task.consumeLegacyAwaitEventTimeout(eventName) {
-			return zero[T](), newTimeoutError(`timed out waiting for event %q`, eventName)
-		}
-
-		row := task.client.db.QueryRowContext(ctx, `SELECT should_suspend, payload
-        FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
-			task.queueName,
-			task.taskID,
-			task.runID,
-			checkpointName,
-			eventName,
-			timeoutSeconds,
-		)
-		if err := row.Scan(&shouldSuspend, &payload); err != nil {
-			return zero[T](), mapTaskStateError(err)
-		}
+		task.queueName,
+		task.taskID,
+		task.runID,
+		checkpointName,
+		eventName,
+		timeoutSeconds,
+	)
+	if err != nil {
+		return zero[T](), mapTaskStateError(err)
 	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return zero[T](), err
+	}
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return zero[T](), mapTaskStateError(err)
+		}
+		return zero[T](), fmt.Errorf("await_event returned no rows")
+	}
+
+	switch len(columns) {
+	case 2:
+		if err := rows.Scan(&shouldSuspend, &payload); err != nil {
+			return zero[T](), mapTaskStateError(err)
+		}
+		timedOut = false
+	case 3:
+		if err := rows.Scan(&shouldSuspend, &payload, &timedOut); err != nil {
+			return zero[T](), mapTaskStateError(err)
+		}
+	default:
+		return zero[T](), fmt.Errorf("await_event returned unexpected column count: %d", len(columns))
+	}
+
 	if shouldSuspend {
 		return zero[T](), errSuspend
 	}
-	if timedOut {
-		task.mu.Lock()
-		task.wakeEvent = ""
-		task.eventRaw = nil
-		task.mu.Unlock()
-		return zero[T](), newTimeoutError(`timed out waiting for event %q`, eventName)
-	}
-	if payload == nil {
+	if timedOut || payload == nil {
 		task.mu.Lock()
 		task.wakeEvent = ""
 		task.eventRaw = nil

--- a/sdks/go/absurd/context.go
+++ b/sdks/go/absurd/context.go
@@ -392,6 +392,7 @@ func AwaitEvent[T any](ctx context.Context, eventName string, options ...AwaitEv
 	var shouldSuspend bool
 	var payload []byte
 	var timedOut bool
+	var hasTimedOutColumn bool
 
 	rows, err := task.client.db.QueryContext(ctx, `SELECT *
         FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
@@ -424,11 +425,13 @@ func AwaitEvent[T any](ctx context.Context, eventName string, options ...AwaitEv
 		if err := rows.Scan(&shouldSuspend, &payload); err != nil {
 			return zero[T](), mapTaskStateError(err)
 		}
+		hasTimedOutColumn = false
 		timedOut = false
 	case 3:
 		if err := rows.Scan(&shouldSuspend, &payload, &timedOut); err != nil {
 			return zero[T](), mapTaskStateError(err)
 		}
+		hasTimedOutColumn = true
 	default:
 		return zero[T](), fmt.Errorf("await_event returned unexpected column count: %d", len(columns))
 	}
@@ -436,7 +439,12 @@ func AwaitEvent[T any](ctx context.Context, eventName string, options ...AwaitEv
 	if shouldSuspend {
 		return zero[T](), errSuspend
 	}
-	if timedOut || payload == nil {
+
+	legacyTimedOut := !hasTimedOutColumn &&
+		payload == nil &&
+		task.wakeEvent == eventName &&
+		task.eventRaw == nil
+	if timedOut || legacyTimedOut {
 		task.mu.Lock()
 		task.wakeEvent = ""
 		task.eventRaw = nil

--- a/sdks/go/absurd/context.go
+++ b/sdks/go/absurd/context.go
@@ -30,10 +30,11 @@ type TaskContext struct {
 	eventRaw        json.RawMessage
 	onLeaseExtended func(time.Duration)
 
-	mu              sync.Mutex
-	headersCache    map[string]any
-	checkpointCache map[string]json.RawMessage
-	stepNameCounter map[string]int
+	mu                                sync.Mutex
+	headersCache                      map[string]any
+	checkpointCache                   map[string]json.RawMessage
+	stepNameCounter                   map[string]int
+	awaitEventTimedOutColumnSupported *bool
 }
 
 var errInvalidTaskHeaders = errors.New("absurd: invalid task headers")
@@ -156,6 +157,58 @@ func (t *TaskContext) nextCheckpointName(name string) string {
 		return name
 	}
 	return fmt.Sprintf("%s#%d", name, count)
+}
+
+func (t *TaskContext) getAwaitEventTimedOutColumnSupport() (bool, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.awaitEventTimedOutColumnSupported == nil {
+		return false, false
+	}
+	return *t.awaitEventTimedOutColumnSupported, true
+}
+
+func (t *TaskContext) setAwaitEventTimedOutColumnSupport(value bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	v := value
+	t.awaitEventTimedOutColumnSupported = &v
+}
+
+func (t *TaskContext) ensureAwaitEventTimedOutColumnSupport(ctx context.Context) (bool, error) {
+	if cached, ok := t.getAwaitEventTimedOutColumnSupport(); ok {
+		return cached, nil
+	}
+
+	row := t.client.db.QueryRowContext(ctx, `SELECT EXISTS (
+			SELECT 1
+			  FROM pg_catalog.pg_proc p
+			  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+			  JOIN LATERAL unnest(p.proargmodes, p.proargnames)
+			    WITH ORDINALITY AS out_args(mode, name, ord) ON true
+			 WHERE n.nspname = 'absurd'
+			   AND p.proname = 'await_event'
+			   AND out_args.mode IN ('o', 't')
+			   AND out_args.name = 'timed_out'
+		) AS supported`)
+
+	var supported bool
+	if err := row.Scan(&supported); err != nil {
+		return false, err
+	}
+	t.setAwaitEventTimedOutColumnSupport(supported)
+	return supported, nil
+}
+
+func (t *TaskContext) consumeLegacyAwaitEventTimeout(eventName string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.wakeEvent != eventName || t.eventRaw != nil {
+		return false
+	}
+	t.wakeEvent = ""
+	t.eventRaw = nil
+	return true
 }
 
 func (t *TaskContext) lookupCheckpoint(ctx context.Context, checkpointName string) (json.RawMessage, bool, error) {
@@ -381,28 +434,67 @@ func AwaitEvent[T any](ctx context.Context, eventName string, options ...AwaitEv
 		}
 		return value, nil
 	}
+
+	timedOutSupport, err := task.ensureAwaitEventTimedOutColumnSupport(ctx)
+	if err != nil {
+		return zero[T](), err
+	}
+
+	if !timedOutSupport && task.consumeLegacyAwaitEventTimeout(eventName) {
+		return zero[T](), newTimeoutError(`timed out waiting for event %q`, eventName)
+	}
+
 	var timeoutSeconds any = nil
 	if opts.Timeout > 0 {
 		timeoutSeconds = durationSeconds(opts.Timeout)
 	} else if opts.Timeout < 0 {
 		timeoutSeconds = 0
 	}
-	row := task.client.db.QueryRowContext(ctx, `SELECT should_suspend, payload
-        FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
-		task.queueName,
-		task.taskID,
-		task.runID,
-		checkpointName,
-		eventName,
-		timeoutSeconds,
-	)
+
 	var shouldSuspend bool
 	var payload []byte
-	if err := row.Scan(&shouldSuspend, &payload); err != nil {
-		return zero[T](), mapTaskStateError(err)
+	var timedOut bool
+
+	if timedOutSupport {
+		row := task.client.db.QueryRowContext(ctx, `SELECT should_suspend, payload, timed_out
+        FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
+			task.queueName,
+			task.taskID,
+			task.runID,
+			checkpointName,
+			eventName,
+			timeoutSeconds,
+		)
+		if err := row.Scan(&shouldSuspend, &payload, &timedOut); err != nil {
+			return zero[T](), mapTaskStateError(err)
+		}
+	} else {
+		if task.consumeLegacyAwaitEventTimeout(eventName) {
+			return zero[T](), newTimeoutError(`timed out waiting for event %q`, eventName)
+		}
+
+		row := task.client.db.QueryRowContext(ctx, `SELECT should_suspend, payload
+        FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
+			task.queueName,
+			task.taskID,
+			task.runID,
+			checkpointName,
+			eventName,
+			timeoutSeconds,
+		)
+		if err := row.Scan(&shouldSuspend, &payload); err != nil {
+			return zero[T](), mapTaskStateError(err)
+		}
 	}
 	if shouldSuspend {
 		return zero[T](), errSuspend
+	}
+	if timedOut {
+		task.mu.Lock()
+		task.wakeEvent = ""
+		task.eventRaw = nil
+		task.mu.Unlock()
+		return zero[T](), newTimeoutError(`timed out waiting for event %q`, eventName)
 	}
 	if payload == nil {
 		task.mu.Lock()

--- a/sdks/go/absurd/context_compat_test.go
+++ b/sdks/go/absurd/context_compat_test.go
@@ -1,0 +1,60 @@
+package absurd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestAwaitEventLegacyTimeoutFallbackWithoutTimedOutColumn(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	eventName := "legacy-timeout-event"
+	checkpointName := "$awaitEvent:" + eventName
+	client := &Client{db: db, queueName: "default"}
+	taskCtx := &TaskContext{
+		client:          client,
+		queueName:       "default",
+		taskID:          "task-1",
+		runID:           "run-1",
+		claimTimeout:    60 * time.Second,
+		wakeEvent:       eventName,
+		eventRaw:        nil,
+		checkpointCache: make(map[string]json.RawMessage),
+		stepNameCounter: make(map[string]int),
+	}
+	taskCtx.Context = context.WithValue(context.Background(), taskContextKey{}, taskCtx)
+
+	mock.ExpectQuery(`SELECT state\s+FROM absurd\.get_task_checkpoint_state\(\$1, \$2, \$3\)`).
+		WithArgs("default", "task-1", checkpointName).
+		WillReturnRows(sqlmock.NewRows([]string{"state"}))
+
+	mock.ExpectQuery(`SELECT \*\s+FROM absurd\.await_event\(\$1, \$2, \$3, \$4, \$5, \$6\)`).
+		WithArgs("default", "task-1", "run-1", checkpointName, eventName, nil).
+		WillReturnRows(sqlmock.NewRows([]string{"should_suspend", "payload"}).AddRow(false, nil))
+
+	_, err = AwaitEvent[map[string]any](taskCtx, eventName)
+	var timeoutErr *TimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("expected TimeoutError, got %v", err)
+	}
+
+	if taskCtx.wakeEvent != "" {
+		t.Fatalf("expected wakeEvent to be cleared, got %q", taskCtx.wakeEvent)
+	}
+	if taskCtx.eventRaw != nil {
+		t.Fatalf("expected eventRaw to be cleared, got %#v", taskCtx.eventRaw)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/sdks/go/absurd/go.mod
+++ b/sdks/go/absurd/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require github.com/jackc/pgx/v5 v5.7.6
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/sdks/go/absurd/go.sum
+++ b/sdks/go/absurd/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,6 +11,7 @@ github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
 github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/sdks/go/tests/absurd_test.go
+++ b/sdks/go/tests/absurd_test.go
@@ -387,6 +387,51 @@ func TestQuickstartStyleAwaitEventFlow(t *testing.T) {
 	}
 }
 
+func TestAwaitEventSupportsPayloadLikeLegacyTimeoutSentinel(t *testing.T) {
+	queue := randomQueueName("go_sentinel_payload")
+	client := newTestClient(t, queue)
+
+	client.MustRegister(absurd.Task("sentinel-payload-waiter", func(ctx context.Context, params map[string]any) (map[string]any, error) {
+		received, err := absurd.AwaitEvent[map[string]any](ctx, "sentinel-payload-event")
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"received": received}, nil
+	}))
+
+	if err := client.EmitEvent(context.Background(), queue, "sentinel-payload-event", map[string]any{"$awaitEventTimeout": true}); err != nil {
+		t.Fatalf("EmitEvent failed: %v", err)
+	}
+
+	spawned, err := client.Spawn(context.Background(), "sentinel-payload-waiter", nil)
+	if err != nil {
+		t.Fatalf("Spawn failed: %v", err)
+	}
+
+	if err := client.WorkBatch(context.Background(), absurd.WorkBatchOptions{WorkerID: "worker"}); err != nil {
+		t.Fatalf("WorkBatch failed: %v", err)
+	}
+
+	snapshot, err := client.AwaitTaskResult(context.Background(), queue, spawned.TaskID, absurd.AwaitTaskResultOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("AwaitTaskResult failed: %v", err)
+	}
+	if snapshot.State != absurd.TaskCompleted {
+		t.Fatalf("unexpected task state: %s", snapshot.State)
+	}
+	var result map[string]map[string]any
+	if err := snapshot.DecodeResult(&result); err != nil {
+		t.Fatalf("DecodeResult failed: %v", err)
+	}
+	received, ok := result["received"]
+	if !ok {
+		t.Fatalf("missing received payload: %#v", result)
+	}
+	if received["$awaitEventTimeout"] != true {
+		t.Fatalf("unexpected payload: %#v", received)
+	}
+}
+
 func TestRunWorkerAndAwaitTaskResult(t *testing.T) {
 	queue := randomQueueName("go_worker")
 	client := newTestClient(t, queue)
@@ -502,6 +547,92 @@ func TestAwaitEventNegativeTimeoutDoesNotSleepForever(t *testing.T) {
 	}
 	if !result["timed_out"] {
 		t.Fatalf("expected timeout result, got %#v", result)
+	}
+}
+
+func TestAwaitEventTimeoutCheckpointPreservesProgressAcrossMultipleAwaits(t *testing.T) {
+	queue := randomQueueName("go_timeout_loop")
+	db := setupTestDatabase(t)
+	client := newTestClient(t, queue)
+
+	baseTime := time.Date(2024, 5, 2, 13, 0, 0, 0, time.UTC)
+	setFakeNow(t, db, &baseTime)
+	defer setFakeNow(t, db, nil)
+
+	client.MustRegister(absurd.Task("timeout-loop", func(ctx context.Context, params map[string]any) (map[string]any, error) {
+		stages := make([]string, 0, 2)
+		for cycle := 0; cycle < 2; cycle++ {
+			_, err := absurd.AwaitEvent[map[string]any](ctx, fmt.Sprintf("wake:%d", cycle), absurd.AwaitEventOptions{
+				StepName: fmt.Sprintf("await-%d", cycle),
+				Timeout:  10 * time.Second,
+			})
+			if err != nil {
+				var timeoutErr *absurd.TimeoutError
+				if errors.As(err, &timeoutErr) {
+					stages = append(stages, fmt.Sprintf("timeout-%d", cycle))
+					continue
+				}
+				return nil, err
+			}
+			stages = append(stages, fmt.Sprintf("event-%d", cycle))
+		}
+		return map[string]any{"stages": stages}, nil
+	}))
+
+	spawned, err := client.Spawn(context.Background(), "timeout-loop", nil)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	if err := client.WorkBatch(context.Background(), absurd.WorkBatchOptions{WorkerID: "worker-timeout"}); err != nil {
+		t.Fatalf("WorkBatch first pass: %v", err)
+	}
+
+	t1 := baseTime.Add(15 * time.Second)
+	setFakeNow(t, db, &t1)
+	if err := client.WorkBatch(context.Background(), absurd.WorkBatchOptions{WorkerID: "worker-timeout"}); err != nil {
+		t.Fatalf("WorkBatch second pass: %v", err)
+	}
+
+	var runState string
+	var wakeEvent sql.NullString
+	runQuery := fmt.Sprintf(`select state, wake_event from absurd.r_%s where run_id = $1`, queue)
+	if err := db.QueryRow(runQuery, spawned.RunID).Scan(&runState, &wakeEvent); err != nil {
+		t.Fatalf("fetch mid run: %v", err)
+	}
+	if runState != "sleeping" || !wakeEvent.Valid || wakeEvent.String != "wake:1" {
+		t.Fatalf("expected sleeping on wake:1, got state=%q wake_event=%v", runState, wakeEvent)
+	}
+
+	t2 := baseTime.Add(30 * time.Second)
+	setFakeNow(t, db, &t2)
+	if err := client.WorkBatch(context.Background(), absurd.WorkBatchOptions{WorkerID: "worker-timeout"}); err != nil {
+		t.Fatalf("WorkBatch third pass: %v", err)
+	}
+
+	snapshot, err := client.AwaitTaskResult(context.Background(), queue, spawned.TaskID, absurd.AwaitTaskResultOptions{Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("AwaitTaskResult: %v", err)
+	}
+	if snapshot.State != absurd.TaskCompleted {
+		t.Fatalf("expected completed state, got %s", snapshot.State)
+	}
+	var result map[string]any
+	if err := snapshot.DecodeResult(&result); err != nil {
+		t.Fatalf("DecodeResult: %v", err)
+	}
+	stages, ok := result["stages"].([]any)
+	if !ok || len(stages) != 2 || stages[0] != "timeout-0" || stages[1] != "timeout-1" {
+		t.Fatalf("unexpected stages: %#v", result["stages"])
+	}
+
+	var waitCount int
+	waitQuery := fmt.Sprintf(`select count(*) from absurd.w_%s`, queue)
+	if err := db.QueryRow(waitQuery).Scan(&waitCount); err != nil {
+		t.Fatalf("count waits: %v", err)
+	}
+	if waitCount != 0 {
+		t.Fatalf("expected no outstanding waits, got %d", waitCount)
 	}
 }
 

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -641,6 +641,7 @@ def _create_task_context(
     ctx._checkpoint_cache = cache
     ctx._claim_timeout = claim_timeout
     ctx._step_name_counter = {}
+    ctx._await_event_timed_out_column_supported = None
     return ctx
 
 
@@ -668,6 +669,7 @@ async def _create_async_task_context(
     ctx._checkpoint_cache = cache
     ctx._claim_timeout = claim_timeout
     ctx._step_name_counter = {}
+    ctx._await_event_timed_out_column_supported = None
     return ctx
 
 
@@ -681,6 +683,7 @@ class TaskContext:
     _checkpoint_cache: Dict[str, JsonValue]
     _claim_timeout: int
     _step_name_counter: Dict[str, int]
+    _await_event_timed_out_column_supported: Optional[bool]
 
     def __init__(self):
         raise TypeError("Cannot create TaskContext instances")
@@ -802,33 +805,56 @@ class TaskContext:
         if cached is not _CHECKPOINT_NOT_FOUND:
             return cast(JsonValue, cached)
 
-        if (
-            self._task["wake_event"] == event_name
+        timed_out_column_supported = self._ensure_await_event_timed_out_column_support()
+
+        run_legacy_timeout_path = (
+            not timed_out_column_supported
+            and self._task["wake_event"] == event_name
             and self._task["event_payload"] is None
-        ):
+        )
+        if run_legacy_timeout_path:
             self._task["wake_event"] = None
             self._task["event_payload"] = None
             raise TimeoutError(f'Timed out waiting for event "{event_name}"')
 
         cursor = self._conn.cursor(row_factory=dict_row)
         with _task_state_exception_handling():
-            cursor.execute(
-                """SELECT should_suspend, payload
-                   FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
-                (
-                    self._queue_name,
-                    self._task["task_id"],
-                    self._task["run_id"],
-                    checkpoint_name,
-                    event_name,
-                    timeout,
-                ),
-            )
+            if timed_out_column_supported:
+                cursor.execute(
+                    """SELECT should_suspend, payload, timed_out
+                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
+                    (
+                        self._queue_name,
+                        self._task["task_id"],
+                        self._task["run_id"],
+                        checkpoint_name,
+                        event_name,
+                        timeout,
+                    ),
+                )
+            else:
+                cursor.execute(
+                    """SELECT should_suspend, payload
+                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
+                    (
+                        self._queue_name,
+                        self._task["task_id"],
+                        self._task["run_id"],
+                        checkpoint_name,
+                        event_name,
+                        timeout,
+                    ),
+                )
 
         result = cursor.fetchone()
 
         if not result:
             raise Exception("Failed to await event")
+
+        if result.get("timed_out"):
+            self._task["wake_event"] = None
+            self._task["event_payload"] = None
+            raise TimeoutError(f'Timed out waiting for event "{event_name}"')
 
         if not result["should_suspend"]:
             self._checkpoint_cache[checkpoint_name] = result["payload"]
@@ -907,6 +933,30 @@ class TaskContext:
         self._step_name_counter[name] = count
         return name if count == 1 else f"{name}#{count}"
 
+    def _ensure_await_event_timed_out_column_support(self) -> bool:
+        if self._await_event_timed_out_column_supported is not None:
+            return self._await_event_timed_out_column_supported
+
+        cursor = self._conn.cursor(row_factory=dict_row)
+        cursor.execute(
+            """SELECT EXISTS (
+                   SELECT 1
+                     FROM pg_catalog.pg_proc p
+                     JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+                     JOIN LATERAL unnest(p.proargmodes, p.proargnames)
+                       WITH ORDINALITY AS out_args(mode, name, ord) ON true
+                    WHERE n.nspname = 'absurd'
+                      AND p.proname = 'await_event'
+                      AND out_args.mode IN ('o', 't')
+                      AND out_args.name = 'timed_out'
+               ) AS supported"""
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise Exception("Failed to detect absurd.await_event timed_out support")
+        self._await_event_timed_out_column_supported = bool(row["supported"])
+        return self._await_event_timed_out_column_supported
+
     def _lookup_checkpoint(self, checkpoint_name: str) -> Union[JsonValue, object]:
         """Look up a checkpoint by name"""
         if checkpoint_name in self._checkpoint_cache:
@@ -963,6 +1013,7 @@ class AsyncTaskContext:
     _checkpoint_cache: Dict[str, JsonValue]
     _claim_timeout: int
     _step_name_counter: Dict[str, int]
+    _await_event_timed_out_column_supported: Optional[bool]
 
     def __init__(self):
         raise TypeError("Cannot create AsyncTaskContext instances")
@@ -1044,33 +1095,58 @@ class AsyncTaskContext:
         if cached is not _CHECKPOINT_NOT_FOUND:
             return cast(JsonValue, cached)
 
-        if (
-            self._task["wake_event"] == event_name
+        timed_out_column_supported = (
+            await self._ensure_await_event_timed_out_column_support()
+        )
+
+        run_legacy_timeout_path = (
+            not timed_out_column_supported
+            and self._task["wake_event"] == event_name
             and self._task["event_payload"] is None
-        ):
+        )
+        if run_legacy_timeout_path:
             self._task["wake_event"] = None
             self._task["event_payload"] = None
             raise TimeoutError(f'Timed out waiting for event "{event_name}"')
 
         cursor = self._conn.cursor(row_factory=dict_row)
         with _task_state_exception_handling():
-            await cursor.execute(
-                """SELECT should_suspend, payload
-                   FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
-                (
-                    self._queue_name,
-                    self._task["task_id"],
-                    self._task["run_id"],
-                    checkpoint_name,
-                    event_name,
-                    timeout,
-                ),
-            )
+            if timed_out_column_supported:
+                await cursor.execute(
+                    """SELECT should_suspend, payload, timed_out
+                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
+                    (
+                        self._queue_name,
+                        self._task["task_id"],
+                        self._task["run_id"],
+                        checkpoint_name,
+                        event_name,
+                        timeout,
+                    ),
+                )
+            else:
+                await cursor.execute(
+                    """SELECT should_suspend, payload
+                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
+                    (
+                        self._queue_name,
+                        self._task["task_id"],
+                        self._task["run_id"],
+                        checkpoint_name,
+                        event_name,
+                        timeout,
+                    ),
+                )
 
         result = await cursor.fetchone()
 
         if not result:
             raise Exception("Failed to await event")
+
+        if result.get("timed_out"):
+            self._task["wake_event"] = None
+            self._task["event_payload"] = None
+            raise TimeoutError(f'Timed out waiting for event "{event_name}"')
 
         if not result["should_suspend"]:
             self._checkpoint_cache[checkpoint_name] = result["payload"]
@@ -1150,6 +1226,30 @@ class AsyncTaskContext:
         count = self._step_name_counter.get(name, 0) + 1
         self._step_name_counter[name] = count
         return name if count == 1 else f"{name}#{count}"
+
+    async def _ensure_await_event_timed_out_column_support(self) -> bool:
+        if self._await_event_timed_out_column_supported is not None:
+            return self._await_event_timed_out_column_supported
+
+        cursor = self._conn.cursor(row_factory=dict_row)
+        await cursor.execute(
+            """SELECT EXISTS (
+                   SELECT 1
+                     FROM pg_catalog.pg_proc p
+                     JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+                     JOIN LATERAL unnest(p.proargmodes, p.proargnames)
+                       WITH ORDINALITY AS out_args(mode, name, ord) ON true
+                    WHERE n.nspname = 'absurd'
+                      AND p.proname = 'await_event'
+                      AND out_args.mode IN ('o', 't')
+                      AND out_args.name = 'timed_out'
+               ) AS supported"""
+        )
+        row = await cursor.fetchone()
+        if not row:
+            raise Exception("Failed to detect absurd.await_event timed_out support")
+        self._await_event_timed_out_column_supported = bool(row["supported"])
+        return self._await_event_timed_out_column_supported
 
     async def _lookup_checkpoint(
         self, checkpoint_name: str

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -828,7 +828,19 @@ class TaskContext:
         ):
             raise Exception("absurd.await_event returned an invalid row shape")
 
-        if result.get("timed_out") is True:
+        has_timed_out_field = "timed_out" in result
+        timed_out = (
+            result.get("timed_out") is True
+            if has_timed_out_field
+            else (
+                result["should_suspend"] is False
+                and result["payload"] is None
+                and self._task.get("wake_event") == event_name
+                and self._task.get("event_payload") is None
+            )
+        )
+
+        if timed_out:
             self._task["wake_event"] = None
             self._task["event_payload"] = None
             raise TimeoutError(f'Timed out waiting for event "{event_name}"')
@@ -1073,7 +1085,19 @@ class AsyncTaskContext:
         ):
             raise Exception("absurd.await_event returned an invalid row shape")
 
-        if result.get("timed_out") is True:
+        has_timed_out_field = "timed_out" in result
+        timed_out = (
+            result.get("timed_out") is True
+            if has_timed_out_field
+            else (
+                result["should_suspend"] is False
+                and result["payload"] is None
+                and self._task.get("wake_event") == event_name
+                and self._task.get("event_payload") is None
+            )
+        )
+
+        if timed_out:
             self._task["wake_event"] = None
             self._task["event_payload"] = None
             raise TimeoutError(f'Timed out waiting for event "{event_name}"')

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -641,7 +641,6 @@ def _create_task_context(
     ctx._checkpoint_cache = cache
     ctx._claim_timeout = claim_timeout
     ctx._step_name_counter = {}
-    ctx._await_event_timed_out_column_supported = None
     return ctx
 
 
@@ -669,7 +668,6 @@ async def _create_async_task_context(
     ctx._checkpoint_cache = cache
     ctx._claim_timeout = claim_timeout
     ctx._step_name_counter = {}
-    ctx._await_event_timed_out_column_supported = None
     return ctx
 
 
@@ -683,7 +681,6 @@ class TaskContext:
     _checkpoint_cache: Dict[str, JsonValue]
     _claim_timeout: int
     _step_name_counter: Dict[str, int]
-    _await_event_timed_out_column_supported: Optional[bool]
 
     def __init__(self):
         raise TypeError("Cannot create TaskContext instances")
@@ -805,53 +802,33 @@ class TaskContext:
         if cached is not _CHECKPOINT_NOT_FOUND:
             return cast(JsonValue, cached)
 
-        timed_out_column_supported = self._ensure_await_event_timed_out_column_support()
-
-        run_legacy_timeout_path = (
-            not timed_out_column_supported
-            and self._task["wake_event"] == event_name
-            and self._task["event_payload"] is None
-        )
-        if run_legacy_timeout_path:
-            self._task["wake_event"] = None
-            self._task["event_payload"] = None
-            raise TimeoutError(f'Timed out waiting for event "{event_name}"')
-
         cursor = self._conn.cursor(row_factory=dict_row)
         with _task_state_exception_handling():
-            if timed_out_column_supported:
-                cursor.execute(
-                    """SELECT should_suspend, payload, timed_out
-                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
-                    (
-                        self._queue_name,
-                        self._task["task_id"],
-                        self._task["run_id"],
-                        checkpoint_name,
-                        event_name,
-                        timeout,
-                    ),
-                )
-            else:
-                cursor.execute(
-                    """SELECT should_suspend, payload
-                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
-                    (
-                        self._queue_name,
-                        self._task["task_id"],
-                        self._task["run_id"],
-                        checkpoint_name,
-                        event_name,
-                        timeout,
-                    ),
-                )
+            cursor.execute(
+                """SELECT *
+                   FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
+                (
+                    self._queue_name,
+                    self._task["task_id"],
+                    self._task["run_id"],
+                    checkpoint_name,
+                    event_name,
+                    timeout,
+                ),
+            )
 
         result = cursor.fetchone()
 
         if not result:
             raise Exception("Failed to await event")
 
-        if result.get("timed_out"):
+        if (
+            not isinstance(result.get("should_suspend"), bool)
+            or "payload" not in result
+        ):
+            raise Exception("absurd.await_event returned an invalid row shape")
+
+        if result.get("timed_out") is True:
             self._task["wake_event"] = None
             self._task["event_payload"] = None
             raise TimeoutError(f'Timed out waiting for event "{event_name}"')
@@ -933,30 +910,6 @@ class TaskContext:
         self._step_name_counter[name] = count
         return name if count == 1 else f"{name}#{count}"
 
-    def _ensure_await_event_timed_out_column_support(self) -> bool:
-        if self._await_event_timed_out_column_supported is not None:
-            return self._await_event_timed_out_column_supported
-
-        cursor = self._conn.cursor(row_factory=dict_row)
-        cursor.execute(
-            """SELECT EXISTS (
-                   SELECT 1
-                     FROM pg_catalog.pg_proc p
-                     JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-                     JOIN LATERAL unnest(p.proargmodes, p.proargnames)
-                       WITH ORDINALITY AS out_args(mode, name, ord) ON true
-                    WHERE n.nspname = 'absurd'
-                      AND p.proname = 'await_event'
-                      AND out_args.mode IN ('o', 't')
-                      AND out_args.name = 'timed_out'
-               ) AS supported"""
-        )
-        row = cursor.fetchone()
-        if not row:
-            raise Exception("Failed to detect absurd.await_event timed_out support")
-        self._await_event_timed_out_column_supported = bool(row["supported"])
-        return self._await_event_timed_out_column_supported
-
     def _lookup_checkpoint(self, checkpoint_name: str) -> Union[JsonValue, object]:
         """Look up a checkpoint by name"""
         if checkpoint_name in self._checkpoint_cache:
@@ -1013,7 +966,6 @@ class AsyncTaskContext:
     _checkpoint_cache: Dict[str, JsonValue]
     _claim_timeout: int
     _step_name_counter: Dict[str, int]
-    _await_event_timed_out_column_supported: Optional[bool]
 
     def __init__(self):
         raise TypeError("Cannot create AsyncTaskContext instances")
@@ -1095,55 +1047,33 @@ class AsyncTaskContext:
         if cached is not _CHECKPOINT_NOT_FOUND:
             return cast(JsonValue, cached)
 
-        timed_out_column_supported = (
-            await self._ensure_await_event_timed_out_column_support()
-        )
-
-        run_legacy_timeout_path = (
-            not timed_out_column_supported
-            and self._task["wake_event"] == event_name
-            and self._task["event_payload"] is None
-        )
-        if run_legacy_timeout_path:
-            self._task["wake_event"] = None
-            self._task["event_payload"] = None
-            raise TimeoutError(f'Timed out waiting for event "{event_name}"')
-
         cursor = self._conn.cursor(row_factory=dict_row)
         with _task_state_exception_handling():
-            if timed_out_column_supported:
-                await cursor.execute(
-                    """SELECT should_suspend, payload, timed_out
-                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
-                    (
-                        self._queue_name,
-                        self._task["task_id"],
-                        self._task["run_id"],
-                        checkpoint_name,
-                        event_name,
-                        timeout,
-                    ),
-                )
-            else:
-                await cursor.execute(
-                    """SELECT should_suspend, payload
-                       FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
-                    (
-                        self._queue_name,
-                        self._task["task_id"],
-                        self._task["run_id"],
-                        checkpoint_name,
-                        event_name,
-                        timeout,
-                    ),
-                )
+            await cursor.execute(
+                """SELECT *
+                   FROM absurd.await_event(%s, %s, %s, %s, %s, %s)""",
+                (
+                    self._queue_name,
+                    self._task["task_id"],
+                    self._task["run_id"],
+                    checkpoint_name,
+                    event_name,
+                    timeout,
+                ),
+            )
 
         result = await cursor.fetchone()
 
         if not result:
             raise Exception("Failed to await event")
 
-        if result.get("timed_out"):
+        if (
+            not isinstance(result.get("should_suspend"), bool)
+            or "payload" not in result
+        ):
+            raise Exception("absurd.await_event returned an invalid row shape")
+
+        if result.get("timed_out") is True:
             self._task["wake_event"] = None
             self._task["event_payload"] = None
             raise TimeoutError(f'Timed out waiting for event "{event_name}"')
@@ -1226,30 +1156,6 @@ class AsyncTaskContext:
         count = self._step_name_counter.get(name, 0) + 1
         self._step_name_counter[name] = count
         return name if count == 1 else f"{name}#{count}"
-
-    async def _ensure_await_event_timed_out_column_support(self) -> bool:
-        if self._await_event_timed_out_column_supported is not None:
-            return self._await_event_timed_out_column_supported
-
-        cursor = self._conn.cursor(row_factory=dict_row)
-        await cursor.execute(
-            """SELECT EXISTS (
-                   SELECT 1
-                     FROM pg_catalog.pg_proc p
-                     JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-                     JOIN LATERAL unnest(p.proargmodes, p.proargnames)
-                       WITH ORDINALITY AS out_args(mode, name, ord) ON true
-                    WHERE n.nspname = 'absurd'
-                      AND p.proname = 'await_event'
-                      AND out_args.mode IN ('o', 't')
-                      AND out_args.name = 'timed_out'
-               ) AS supported"""
-        )
-        row = await cursor.fetchone()
-        if not row:
-            raise Exception("Failed to detect absurd.await_event timed_out support")
-        self._await_event_timed_out_column_supported = bool(row["supported"])
-        return self._await_event_timed_out_column_supported
 
     async def _lookup_checkpoint(
         self, checkpoint_name: str

--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -1,8 +1,10 @@
 """Tests for event system"""
 
 from datetime import datetime, timezone, timedelta
+import psycopg
 from psycopg import sql
 
+import absurd_sdk
 from absurd_sdk import Absurd, TimeoutError
 
 
@@ -99,6 +101,29 @@ def test_event_emitted_before_await_is_cached(conn, queue_name):
     spawned = client.spawn("late-waiter", None)
 
     # Should complete immediately with cached event
+    client.work_batch("worker1", 60, 1)
+
+    task = _get_task(conn, queue, spawned["task_id"])
+    assert task["state"] == "completed"
+    assert task["completed_payload"] == {"received": payload}
+
+
+def test_await_event_supports_payload_like_legacy_timeout_sentinel(conn, queue_name):
+    queue = queue_name("sentinel_payload_event")
+    client = Absurd(conn, queue_name=queue)
+    client.create_queue()
+
+    event_name = f"sentinel_payload_event_{queue}"
+    payload = {"$awaitEventTimeout": True}
+
+    @client.register_task("sentinel-payload-waiter")
+    def sentinel_payload_waiter_task(params, ctx):
+        received = ctx.await_event(event_name)
+        return {"received": received}
+
+    client.emit_event(event_name, payload)
+
+    spawned = client.spawn("sentinel-payload-waiter", None)
     client.work_batch("worker1", 60, 1)
 
     task = _get_task(conn, queue, spawned["task_id"])
@@ -233,8 +258,8 @@ def test_multiple_tasks_can_await_same_event(conn, queue_name):
         assert task["completed_payload"] == {"taskNum": i + 1, "received": payload}
 
 
-def test_await_event_timeout_does_not_recreate_wait_on_resume(conn, queue_name):
-    """Test that awaitEvent timeout does not recreate wait registration on resume"""
+def test_await_event_timeout_clears_wait_registration(conn, queue_name):
+    """Test that awaitEvent timeout cleans up wait registration."""
     queue = queue_name("timeout_no_loop")
     client = Absurd(conn, queue_name=queue)
     client.create_queue()
@@ -249,8 +274,7 @@ def test_await_event_timeout_does_not_recreate_wait_on_resume(conn, queue_name):
             ctx.await_event(event_name, step_name="wait", timeout=10)
             return {"stage": "unexpected"}
         except TimeoutError:
-            payload = ctx.await_event(event_name, step_name="wait", timeout=10)
-            return {"stage": "resumed", "payload": payload}
+            return {"stage": "timed-out"}
 
     spawned = client.spawn("timeout-no-loop", None)
     client.work_batch("worker-timeout", 60, 1)
@@ -272,4 +296,95 @@ def test_await_event_timeout_does_not_recreate_wait_on_resume(conn, queue_name):
 
     task = _get_task(conn, queue, spawned["task_id"])
     assert task["state"] == "completed"
-    assert task["completed_payload"] == {"stage": "resumed", "payload": None}
+    assert task["completed_payload"] == {"stage": "timed-out"}
+
+
+def test_await_event_timeout_checkpoint_preserves_progress_across_multiple_awaits(
+    conn, queue_name
+):
+    queue = queue_name("timeout_loop")
+    client = Absurd(conn, queue_name=queue)
+    client.create_queue()
+
+    base_time = datetime(2024, 5, 2, 13, 0, 0, tzinfo=timezone.utc)
+    _set_fake_now(conn, base_time)
+
+    @client.register_task("timeout-loop")
+    def timeout_loop_task(params, ctx):
+        stages = []
+        for cycle in range(2):
+            try:
+                ctx.await_event(
+                    f"wake:{cycle}",
+                    step_name=f"await-{cycle}",
+                    timeout=10,
+                )
+                stages.append(f"event-{cycle}")
+            except TimeoutError:
+                stages.append(f"timeout-{cycle}")
+        return {"stages": stages}
+
+    spawned = client.spawn("timeout-loop", None)
+    client.work_batch("worker-timeout", 60, 1)
+
+    _set_fake_now(conn, base_time + timedelta(seconds=15))
+    client.work_batch("worker-timeout", 60, 1)
+
+    mid_run = _get_run(conn, queue, spawned["run_id"])
+    assert mid_run["state"] == "sleeping"
+    assert mid_run["wake_event"] == "wake:1"
+
+    _set_fake_now(conn, base_time + timedelta(seconds=30))
+    client.work_batch("worker-timeout", 60, 1)
+
+    task = _get_task(conn, queue, spawned["task_id"])
+    assert task["state"] == "completed"
+    assert task["completed_payload"] == {"stages": ["timeout-0", "timeout-1"]}
+
+    wait_count_query = sql.SQL("SELECT COUNT(*) FROM absurd.{table}").format(
+        table=sql.Identifier(f"w_{queue}")
+    )
+    wait_count_after = conn.execute(wait_count_query).fetchone()[0]
+    assert wait_count_after == 0
+
+
+def test_await_event_legacy_fallback_works_in_transactional_connection(
+    db_dsn, queue_name, monkeypatch
+):
+    queue = queue_name("timeout_tx_fallback")
+
+    monkeypatch.setattr(
+        absurd_sdk.TaskContext,
+        "_ensure_await_event_timed_out_column_support",
+        lambda self: False,
+    )
+
+    with psycopg.connect(db_dsn, autocommit=False) as tx_conn:
+        tx_conn.execute("set timezone to 'UTC'")
+        client = Absurd(tx_conn, queue_name=queue)
+        client.create_queue()
+
+        event_name = f"timeout_tx_fallback_{queue}"
+        base_time = datetime(2024, 5, 2, 14, 0, 0, tzinfo=timezone.utc)
+        _set_fake_now(tx_conn, base_time)
+
+        @client.register_task("timeout-tx-fallback")
+        def timeout_tx_fallback_task(params, ctx):
+            try:
+                ctx.await_event(event_name, step_name="wait", timeout=10)
+                return {"stage": "unexpected"}
+            except TimeoutError:
+                return {"stage": "timed-out"}
+
+        spawned = client.spawn("timeout-tx-fallback", None)
+        client.work_batch("worker-timeout", 60, 1)
+
+        _set_fake_now(tx_conn, base_time + timedelta(seconds=15))
+        client.work_batch("worker-timeout", 60, 1)
+
+        task = _get_task(tx_conn, queue, spawned["task_id"])
+        assert task["state"] == "completed"
+        assert task["completed_payload"] == {"stage": "timed-out"}
+
+        # Ensure the transaction is still usable (no failed-transaction state).
+        assert tx_conn.execute("select 1").fetchone()[0] == 1

--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -435,4 +435,6 @@ def test_await_event_works_in_transactional_connection(db_dsn, queue_name):
         assert task["completed_payload"] == {"stage": "timed-out"}
 
         # Ensure the transaction is still usable (no failed-transaction state).
-        assert tx_conn.execute("select 1").fetchone()[0] == 1
+        row = tx_conn.execute("select 1").fetchone()
+        assert row is not None
+        assert row[0] == 1

--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone, timedelta
 import psycopg
+import pytest
 from psycopg import sql
 
 from absurd_sdk import Absurd, TimeoutError
@@ -345,6 +346,62 @@ def test_await_event_timeout_checkpoint_preserves_progress_across_multiple_await
     )
     wait_count_after = conn.execute(wait_count_query).fetchone()[0]
     assert wait_count_after == 0
+
+
+def test_await_event_timeout_checkpoint_raises_cancellation_after_task_cancel(
+    conn, queue_name
+):
+    queue = queue_name("timeout_cancelled")
+    client = Absurd(conn, queue_name=queue)
+    client.create_queue()
+
+    event_name = f"timeout_cancelled_{queue}"
+    base_time = datetime(2024, 5, 2, 14, 0, 0, tzinfo=timezone.utc)
+    _set_fake_now(conn, base_time)
+
+    @client.register_task("timeout-cancelled")
+    def timeout_cancelled_task(params, ctx):
+        try:
+            ctx.await_event(event_name, step_name="wait", timeout=10)
+            return {"stage": "unexpected"}
+        except TimeoutError:
+            ctx.sleep_for("after-timeout", 3600)
+            return {"stage": "unreachable"}
+
+    spawned = client.spawn("timeout-cancelled", None)
+    client.work_batch("worker-timeout", 60, 1)
+
+    _set_fake_now(conn, base_time + timedelta(seconds=15))
+    client.work_batch("worker-timeout", 60, 1)
+
+    checkpoint_row = conn.execute(
+        sql.SQL(
+            "select state, status from absurd.{table} where task_id = %s and checkpoint_name = %s"
+        ).format(table=sql.Identifier(f"c_{queue}")),
+        (spawned["task_id"], "wait"),
+    ).fetchone()
+    assert checkpoint_row == (None, "timed_out")
+
+    sleeping_run = _get_run(conn, queue, spawned["run_id"])
+    assert sleeping_run["state"] == "sleeping"
+    assert sleeping_run["wake_event"] is None
+
+    client.cancel_task(spawned["task_id"])
+
+    task = _get_task(conn, queue, spawned["task_id"])
+    assert task["state"] == "cancelled"
+
+    cancelled_run = _get_run(conn, queue, spawned["run_id"])
+    assert cancelled_run["state"] == "cancelled"
+
+    with pytest.raises(psycopg.Error) as exc_info:
+        conn.execute(
+            "select * from absurd.await_event(%s, %s, %s, %s, %s, %s)",
+            (queue, spawned["task_id"], spawned["run_id"], "wait", event_name, 10),
+        ).fetchone()
+
+    assert getattr(exc_info.value, "sqlstate", None) == "AB001"
+    assert "cancelled" in str(exc_info.value).lower()
 
 
 def test_await_event_works_in_transactional_connection(db_dsn, queue_name):

--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone, timedelta
 import psycopg
 from psycopg import sql
 
-import absurd_sdk
 from absurd_sdk import Absurd, TimeoutError
 
 
@@ -348,16 +347,8 @@ def test_await_event_timeout_checkpoint_preserves_progress_across_multiple_await
     assert wait_count_after == 0
 
 
-def test_await_event_legacy_fallback_works_in_transactional_connection(
-    db_dsn, queue_name, monkeypatch
-):
+def test_await_event_works_in_transactional_connection(db_dsn, queue_name):
     queue = queue_name("timeout_tx_fallback")
-
-    monkeypatch.setattr(
-        absurd_sdk.TaskContext,
-        "_ensure_await_event_timed_out_column_support",
-        lambda self: False,
-    )
 
     with psycopg.connect(db_dsn, autocommit=False) as tx_conn:
         tx_conn.execute("set timezone to 'UTC'")

--- a/sdks/python/tests/test_events_compat.py
+++ b/sdks/python/tests/test_events_compat.py
@@ -1,0 +1,116 @@
+import asyncio
+import types
+
+import pytest
+
+import absurd_sdk
+from absurd_sdk import AsyncTaskContext, TaskContext, TimeoutError
+
+
+class _Cursor:
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, _query, _params):
+        return None
+
+    def fetchone(self):
+        return self._row
+
+
+class _AsyncCursor:
+    def __init__(self, row):
+        self._row = row
+
+    async def execute(self, _query, _params):
+        return None
+
+    async def fetchone(self):
+        return self._row
+
+
+class _Conn:
+    def __init__(self, row):
+        self._row = row
+
+    def cursor(self, row_factory=None):
+        return _Cursor(self._row)
+
+
+class _AsyncConn:
+    def __init__(self, row):
+        self._row = row
+
+    def cursor(self, row_factory=None):
+        return _AsyncCursor(self._row)
+
+
+def _make_sync_context(event_name: str, row: dict):
+    ctx = object.__new__(TaskContext)
+    ctx.task_id = "task-1"
+    ctx._conn = _Conn(row)
+    ctx._queue_name = "default"
+    ctx._task = {
+        "task_id": "task-1",
+        "run_id": "run-1",
+        "wake_event": event_name,
+        "event_payload": None,
+    }
+    ctx._checkpoint_cache = {}
+    ctx._claim_timeout = 60
+    ctx._step_name_counter = {}
+    ctx._lookup_checkpoint = lambda _checkpoint: absurd_sdk._CHECKPOINT_NOT_FOUND
+    return ctx
+
+
+def _make_async_context(event_name: str, row: dict):
+    ctx = object.__new__(AsyncTaskContext)
+    ctx.task_id = "task-1"
+    ctx._conn = _AsyncConn(row)
+    ctx._queue_name = "default"
+    ctx._task = {
+        "task_id": "task-1",
+        "run_id": "run-1",
+        "wake_event": event_name,
+        "event_payload": None,
+    }
+    ctx._checkpoint_cache = {}
+    ctx._claim_timeout = 60
+    ctx._step_name_counter = {}
+
+    async def _lookup_checkpoint(_self, _checkpoint):
+        return absurd_sdk._CHECKPOINT_NOT_FOUND
+
+    ctx._lookup_checkpoint = types.MethodType(_lookup_checkpoint, ctx)
+    return ctx
+
+
+def test_sync_await_event_legacy_timeout_fallback():
+    event_name = "legacy-timeout-event"
+    ctx = _make_sync_context(
+        event_name,
+        {
+            "should_suspend": False,
+            "payload": None,
+        },
+    )
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for event"):
+        ctx.await_event(event_name)
+
+
+def test_async_await_event_legacy_timeout_fallback():
+    event_name = "legacy-timeout-event"
+    ctx = _make_async_context(
+        event_name,
+        {
+            "should_suspend": False,
+            "payload": None,
+        },
+    )
+
+    async def run():
+        with pytest.raises(TimeoutError, match="Timed out waiting for event"):
+            await ctx.await_event(event_name)
+
+    asyncio.run(run())

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -527,7 +527,16 @@ export class TaskContext {
     const row = result.rows[0];
     const shouldSuspend = row.should_suspend as boolean;
     const payload = row.payload as JsonValue;
-    const timedOut = row.timed_out === true;
+    const hasTimedOutField = Object.prototype.hasOwnProperty.call(
+      row,
+      "timed_out",
+    );
+    const timedOut = hasTimedOutField
+      ? row.timed_out === true
+      : !shouldSuspend &&
+        payload === null &&
+        this.task.wake_event === eventName &&
+        this.task.event_payload === null;
 
     if (timedOut) {
       this.task.wake_event = null;

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -271,7 +271,6 @@ export class TaskContext {
   private readonly checkpointCache: Map<string, JsonValue>;
   private readonly claimTimeout: number;
   private readonly onLeaseExtended: (leaseSeconds: number) => void;
-  private awaitEventTimedOutColumnSupported: boolean | null = null;
 
   private constructor(
     log: Log,
@@ -481,35 +480,6 @@ export class TaskContext {
     ]);
   }
 
-  private async ensureAwaitEventTimedOutColumnSupport(): Promise<boolean> {
-    if (this.awaitEventTimedOutColumnSupported !== null) {
-      return this.awaitEventTimedOutColumnSupported;
-    }
-
-    const result = await this.con.query<{ supported: boolean }>(
-      `SELECT EXISTS (
-         SELECT 1
-           FROM pg_catalog.pg_proc p
-           JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-           JOIN LATERAL unnest(p.proargmodes, p.proargnames)
-             WITH ORDINALITY AS out_args(mode, name, ord) ON true
-          WHERE n.nspname = 'absurd'
-            AND p.proname = 'await_event'
-            AND out_args.mode IN ('o', 't')
-            AND out_args.name = 'timed_out'
-       ) AS supported`,
-    );
-
-    if (result.rows.length === 0) {
-      throw new Error(
-        "Failed to detect absurd.await_event timed_out support",
-      );
-    }
-
-    this.awaitEventTimedOutColumnSupported = Boolean(result.rows[0].supported);
-    return this.awaitEventTimedOutColumnSupported;
-  }
-
   /**
    * Waits for an event by name and returns its payload; optionally sets a custom step name and timeout (seconds).
    * @param eventName Event identifier to wait for.
@@ -537,60 +507,35 @@ export class TaskContext {
       return cached as JsonValue;
     }
 
-    const timedOutColumnSupported =
-      await this.ensureAwaitEventTimedOutColumnSupport();
-
-    const runLegacyTimeoutPath =
-      !timedOutColumnSupported &&
-      this.task.wake_event === eventName &&
-      (this.task.event_payload === null ||
-        this.task.event_payload === undefined);
-
-    if (runLegacyTimeoutPath) {
-      this.task.wake_event = null;
-      this.task.event_payload = null;
-      throw new TimeoutError(`Timed out waiting for event "${eventName}"`);
-    }
-
-    const result = timedOutColumnSupported
-      ? await this.queryWithTaskStateCheck(
-          `SELECT should_suspend, payload, timed_out
-             FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
-          [
-            this.queueName,
-            this.task.task_id,
-            this.task.run_id,
-            checkpointName,
-            eventName,
-            timeout,
-          ],
-        )
-      : await this.queryWithTaskStateCheck(
-          `SELECT should_suspend, payload
-             FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
-          [
-            this.queueName,
-            this.task.task_id,
-            this.task.run_id,
-            checkpointName,
-            eventName,
-            timeout,
-          ],
-        );
+    const result = await this.queryWithTaskStateCheck(
+      `SELECT *
+         FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
+      [
+        this.queueName,
+        this.task.task_id,
+        this.task.run_id,
+        checkpointName,
+        eventName,
+        timeout,
+      ],
+    );
 
     if (result.rows.length === 0) {
       throw new Error("Failed to await event");
     }
 
-    const { should_suspend, payload, timed_out } = result.rows[0];
+    const row = result.rows[0];
+    const shouldSuspend = row.should_suspend as boolean;
+    const payload = row.payload as JsonValue;
+    const timedOut = row.timed_out === true;
 
-    if (timed_out) {
+    if (timedOut) {
       this.task.wake_event = null;
       this.task.event_payload = null;
       throw new TimeoutError(`Timed out waiting for event "${eventName}"`);
     }
 
-    if (!should_suspend) {
+    if (!shouldSuspend) {
       this.checkpointCache.set(checkpointName, payload);
       this.task.event_payload = null;
       return payload;

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -271,6 +271,7 @@ export class TaskContext {
   private readonly checkpointCache: Map<string, JsonValue>;
   private readonly claimTimeout: number;
   private readonly onLeaseExtended: (leaseSeconds: number) => void;
+  private awaitEventTimedOutColumnSupported: boolean | null = null;
 
   private constructor(
     log: Log,
@@ -480,6 +481,35 @@ export class TaskContext {
     ]);
   }
 
+  private async ensureAwaitEventTimedOutColumnSupport(): Promise<boolean> {
+    if (this.awaitEventTimedOutColumnSupported !== null) {
+      return this.awaitEventTimedOutColumnSupported;
+    }
+
+    const result = await this.con.query<{ supported: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1
+           FROM pg_catalog.pg_proc p
+           JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+           JOIN LATERAL unnest(p.proargmodes, p.proargnames)
+             WITH ORDINALITY AS out_args(mode, name, ord) ON true
+          WHERE n.nspname = 'absurd'
+            AND p.proname = 'await_event'
+            AND out_args.mode IN ('o', 't')
+            AND out_args.name = 'timed_out'
+       ) AS supported`,
+    );
+
+    if (result.rows.length === 0) {
+      throw new Error(
+        "Failed to detect absurd.await_event timed_out support",
+      );
+    }
+
+    this.awaitEventTimedOutColumnSupported = Boolean(result.rows[0].supported);
+    return this.awaitEventTimedOutColumnSupported;
+  }
+
   /**
    * Waits for an event by name and returns its payload; optionally sets a custom step name and timeout (seconds).
    * @param eventName Event identifier to wait for.
@@ -506,34 +536,59 @@ export class TaskContext {
     if (cached !== undefined) {
       return cached as JsonValue;
     }
-    if (
+
+    const timedOutColumnSupported =
+      await this.ensureAwaitEventTimedOutColumnSupport();
+
+    const runLegacyTimeoutPath =
+      !timedOutColumnSupported &&
       this.task.wake_event === eventName &&
       (this.task.event_payload === null ||
-        this.task.event_payload === undefined)
-    ) {
+        this.task.event_payload === undefined);
+
+    if (runLegacyTimeoutPath) {
       this.task.wake_event = null;
       this.task.event_payload = null;
       throw new TimeoutError(`Timed out waiting for event "${eventName}"`);
     }
 
-    const result = await this.queryWithTaskStateCheck(
-      `SELECT should_suspend, payload
-        FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
-      [
-        this.queueName,
-        this.task.task_id,
-        this.task.run_id,
-        checkpointName,
-        eventName,
-        timeout,
-      ],
-    );
+    const result = timedOutColumnSupported
+      ? await this.queryWithTaskStateCheck(
+          `SELECT should_suspend, payload, timed_out
+             FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
+          [
+            this.queueName,
+            this.task.task_id,
+            this.task.run_id,
+            checkpointName,
+            eventName,
+            timeout,
+          ],
+        )
+      : await this.queryWithTaskStateCheck(
+          `SELECT should_suspend, payload
+             FROM absurd.await_event($1, $2, $3, $4, $5, $6)`,
+          [
+            this.queueName,
+            this.task.task_id,
+            this.task.run_id,
+            checkpointName,
+            eventName,
+            timeout,
+          ],
+        );
 
     if (result.rows.length === 0) {
       throw new Error("Failed to await event");
     }
 
-    const { should_suspend, payload } = result.rows[0];
+    const { should_suspend, payload, timed_out } = result.rows[0];
+
+    if (timed_out) {
+      this.task.wake_event = null;
+      this.task.event_payload = null;
+      throw new TimeoutError(`Timed out waiting for event "${eventName}"`);
+    }
 
     if (!should_suspend) {
       this.checkpointCache.set(checkpointName, payload);

--- a/sdks/typescript/test/events-compat.test.ts
+++ b/sdks/typescript/test/events-compat.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "./testlib.ts";
+import { TaskContext, type ClaimedTask } from "../src/index.ts";
+
+describe("awaitEvent legacy compatibility", () => {
+  test("treats legacy row shape timeout as TimeoutError", async () => {
+    const eventName = "legacy-timeout-event";
+    const task: ClaimedTask = {
+      run_id: "run-1",
+      task_id: "task-1",
+      task_name: "test",
+      attempt: 1,
+      params: null,
+      retry_strategy: null,
+      max_attempts: null,
+      headers: null,
+      wake_event: eventName,
+      event_payload: null,
+    };
+
+    const con = {
+      query: async (sql: string) => {
+        if (sql.includes("get_task_checkpoint_states")) {
+          return { rows: [] };
+        }
+        if (sql.includes("get_task_checkpoint_state")) {
+          return { rows: [] };
+        }
+        if (sql.includes("await_event")) {
+          return {
+            rows: [
+              {
+                should_suspend: false,
+                payload: null,
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    } as any;
+
+    const ctx = await TaskContext.create({
+      log: console,
+      taskID: task.task_id,
+      con,
+      queueName: "default",
+      task,
+      claimTimeout: 60,
+      onLeaseExtended: () => {},
+    });
+
+    await expect(ctx.awaitEvent(eventName)).rejects.toThrow(
+      `Timed out waiting for event "${eventName}"`,
+    );
+  });
+});

--- a/sdks/typescript/test/events.test.ts
+++ b/sdks/typescript/test/events.test.ts
@@ -76,6 +76,26 @@ describe("Event system", () => {
     });
   });
 
+  test("awaitEvent supports payload that looks like legacy timeout sentinel", async () => {
+    const eventName = randomName("sentinel_payload_event");
+    const payload = { $awaitEventTimeout: true };
+
+    absurd.registerTask({ name: "sentinel-payload-waiter" }, async (_params, ctx) => {
+      const received = await ctx.awaitEvent(eventName);
+      return { received };
+    });
+
+    await absurd.emitEvent(eventName, payload);
+
+    const { taskID } = await absurd.spawn("sentinel-payload-waiter", undefined);
+    await absurd.workBatch("worker1", 60, 1);
+
+    expect(await ctx.getTask(taskID)).toMatchObject({
+      state: "completed",
+      completed_payload: { received: payload },
+    });
+  });
+
   test("emitEvent is first-write-wins", async () => {
     const eventName = randomName("stable_event");
     const firstPayload = { value: 1 };
@@ -209,7 +229,7 @@ describe("Event system", () => {
     }
   });
 
-  test("awaitEvent timeout does not recreate wait on resume", async () => {
+  test("awaitEvent timeout clears wait registration", async () => {
     const eventName = randomName("timeout_no_loop");
     const baseTime = new Date("2024-05-02T11:00:00Z");
     await ctx.setFakeNow(baseTime);
@@ -220,11 +240,7 @@ describe("Event system", () => {
         return { stage: "unexpected" };
       } catch (err) {
         if (err instanceof TimeoutError) {
-          const payload = await ctx.awaitEvent(eventName, {
-            stepName: "wait",
-            timeout: 10,
-          });
-          return { stage: "resumed", payload };
+          return { stage: "timed-out" };
         }
         throw err;
       }
@@ -251,7 +267,55 @@ describe("Event system", () => {
 
     expect(await ctx.getTask(taskID)).toMatchObject({
       state: "completed",
-      completed_payload: { stage: "resumed", payload: null },
+      completed_payload: { stage: "timed-out" },
     });
+  });
+
+  test("awaitEvent timeout checkpoint preserves progress across multiple awaits", async () => {
+    const baseTime = new Date("2024-05-02T13:00:00Z");
+    await ctx.setFakeNow(baseTime);
+
+    absurd.registerTask({ name: "timeout-loop" }, async (_params, ctx) => {
+      const stages: string[] = [];
+      for (let cycle = 0; cycle < 2; cycle++) {
+        try {
+          await ctx.awaitEvent(`wake:${cycle}`, {
+            stepName: `await-${cycle}`,
+            timeout: 10,
+          });
+          stages.push(`event-${cycle}`);
+        } catch (err) {
+          if (err instanceof TimeoutError) {
+            stages.push(`timeout-${cycle}`);
+            continue;
+          }
+          throw err;
+        }
+      }
+      return { stages };
+    });
+
+    const { taskID, runID } = await absurd.spawn("timeout-loop", undefined);
+
+    await absurd.workBatch("worker-timeout", 60, 1);
+
+    await ctx.setFakeNow(new Date(baseTime.getTime() + 15 * 1000));
+    await absurd.workBatch("worker-timeout", 60, 1);
+
+    const midRun = await ctx.getRun(runID);
+    expect(midRun).toMatchObject({ state: "sleeping", wake_event: "wake:1" });
+
+    await ctx.setFakeNow(new Date(baseTime.getTime() + 30 * 1000));
+    await absurd.workBatch("worker-timeout", 60, 1);
+
+    expect(await ctx.getTask(taskID)).toMatchObject({
+      state: "completed",
+      completed_payload: { stages: ["timeout-0", "timeout-1"] },
+    });
+
+    const waitCountAfter = await ctx.pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM absurd.w_${ctx.queueName}`,
+    );
+    expect(Number(waitCountAfter.rows[0].count)).toBe(0);
   });
 });

--- a/sdks/typescript/test/events.test.ts
+++ b/sdks/typescript/test/events.test.ts
@@ -80,10 +80,13 @@ describe("Event system", () => {
     const eventName = randomName("sentinel_payload_event");
     const payload = { $awaitEventTimeout: true };
 
-    absurd.registerTask({ name: "sentinel-payload-waiter" }, async (_params, ctx) => {
-      const received = await ctx.awaitEvent(eventName);
-      return { received };
-    });
+    absurd.registerTask(
+      { name: "sentinel-payload-waiter" },
+      async (_params, ctx) => {
+        const received = await ctx.awaitEvent(eventName);
+        return { received };
+      },
+    );
 
     await absurd.emitEvent(eventName, payload);
 

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -1634,7 +1634,8 @@ create function absurd.await_event (
 )
   returns table (
     should_suspend boolean,
-    payload jsonb
+    payload jsonb,
+    timed_out boolean
   )
   language plpgsql
 as $$
@@ -1643,6 +1644,7 @@ declare
   v_existing_payload jsonb;
   v_event_payload jsonb;
   v_checkpoint_payload jsonb;
+  v_checkpoint_status text;
   v_resolved_payload jsonb;
   v_timeout_at timestamptz;
   v_available_at timestamptz;
@@ -1664,17 +1666,21 @@ begin
   v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
 
   execute format(
-    'select state
+    'select state, status
        from absurd.%I
       where task_id = $1
         and checkpoint_name = $2',
     'c_' || p_queue_name
   )
-  into v_checkpoint_payload
+  into v_checkpoint_payload, v_checkpoint_status
   using p_task_id, p_step_name;
 
-  if v_checkpoint_payload is not null then
-    return query select false, v_checkpoint_payload;
+  if v_checkpoint_status is not null then
+    if v_checkpoint_status = 'timed_out' then
+      return query select false, null::jsonb, true;
+      return;
+    end if;
+    return query select false, v_checkpoint_payload, false;
     return;
   end if;
 
@@ -1762,18 +1768,29 @@ begin
                      updated_at = excluded.updated_at',
       'c_' || p_queue_name
     ) using p_task_id, p_step_name, v_resolved_payload, p_run_id, v_now;
-    return query select false, v_resolved_payload;
+    return query select false, v_resolved_payload, false;
     return;
   end if;
 
   -- Detect if we resumed due to timeout: wake_event matches and payload is null
   if v_resolved_payload is null and v_wake_event = p_event_name and v_existing_payload is null then
-    -- Resumed due to timeout; don't re-sleep and don't create a new wait
+    -- Resumed due to timeout; persist timeout checkpoint and don't re-sleep.
+    execute format(
+      'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+       values ($1, $2, null, ''timed_out'', $3, $4)
+       on conflict (task_id, checkpoint_name)
+       do update set state = excluded.state,
+                     status = excluded.status,
+                     owner_run_id = excluded.owner_run_id,
+                     updated_at = excluded.updated_at',
+      'c_' || p_queue_name
+    ) using p_task_id, p_step_name, p_run_id, v_now;
+
     execute format(
       'update absurd.%I set wake_event = null where run_id = $1',
       'r_' || p_queue_name
     ) using p_run_id;
-    return query select false, null::jsonb;
+    return query select false, null::jsonb, true;
     return;
   end if;
 
@@ -1806,7 +1823,7 @@ begin
     't_' || p_queue_name
   ) using p_task_id;
 
-  return query select true, null::jsonb;
+  return query select true, null::jsonb, false;
   return;
 end;
 $$;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -1676,11 +1676,36 @@ begin
   using p_task_id, p_step_name;
 
   if v_checkpoint_status is not null then
-    if v_checkpoint_status = 'timed_out' then
-      return query select false, null::jsonb, true;
+    if v_checkpoint_status <> 'timed_out' then
+      return query select false, v_checkpoint_payload, false;
       return;
     end if;
-    return query select false, v_checkpoint_payload, false;
+
+    execute format(
+      'select r.state, t.state
+         from absurd.%I r
+         join absurd.%I t on t.task_id = r.task_id
+        where r.run_id = $1
+        for update',
+      'r_' || p_queue_name,
+      't_' || p_queue_name
+    )
+    into v_run_state, v_task_state
+    using p_run_id;
+
+    if v_run_state is null then
+      raise exception 'Run "%" not found while awaiting event', p_run_id;
+    end if;
+
+    if v_task_state = 'cancelled' then
+      raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+    end if;
+
+    if v_run_state <> 'running' then
+      raise exception 'Run "%" must be running to await events', p_run_id;
+    end if;
+
+    return query select false, null::jsonb, true;
     return;
   end if;
 

--- a/sql/migrations/0.3.0-main.sql
+++ b/sql/migrations/0.3.0-main.sql
@@ -865,11 +865,36 @@ begin
   using p_task_id, p_step_name;
 
   if v_checkpoint_status is not null then
-    if v_checkpoint_status = 'timed_out' then
-      return query select false, null::jsonb, true;
+    if v_checkpoint_status <> 'timed_out' then
+      return query select false, v_checkpoint_payload, false;
       return;
     end if;
-    return query select false, v_checkpoint_payload, false;
+
+    execute format(
+      'select r.state, t.state
+         from absurd.%I r
+         join absurd.%I t on t.task_id = r.task_id
+        where r.run_id = $1
+        for update',
+      'r_' || p_queue_name,
+      't_' || p_queue_name
+    )
+    into v_run_state, v_task_state
+    using p_run_id;
+
+    if v_run_state is null then
+      raise exception 'Run "%" not found while awaiting event', p_run_id;
+    end if;
+
+    if v_task_state = 'cancelled' then
+      raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+    end if;
+
+    if v_run_state <> 'running' then
+      raise exception 'Run "%" must be running to await events', p_run_id;
+    end if;
+
+    return query select false, null::jsonb, true;
     return;
   end if;
 

--- a/sql/migrations/0.3.0-main.sql
+++ b/sql/migrations/0.3.0-main.sql
@@ -811,6 +811,212 @@ begin
 end;
 $$;
 
+drop function if exists absurd.await_event(text, uuid, uuid, text, text, integer);
+
+create function absurd.await_event (
+  p_queue_name text,
+  p_task_id uuid,
+  p_run_id uuid,
+  p_step_name text,
+  p_event_name text,
+  p_timeout integer default null
+)
+  returns table (
+    should_suspend boolean,
+    payload jsonb,
+    timed_out boolean
+  )
+  language plpgsql
+as $$
+declare
+  v_run_state text;
+  v_existing_payload jsonb;
+  v_event_payload jsonb;
+  v_checkpoint_payload jsonb;
+  v_checkpoint_status text;
+  v_resolved_payload jsonb;
+  v_timeout_at timestamptz;
+  v_available_at timestamptz;
+  v_now timestamptz := absurd.current_time();
+  v_task_state text;
+  v_wake_event text;
+begin
+  if p_event_name is null or length(trim(p_event_name)) = 0 then
+    raise exception 'event_name must be provided';
+  end if;
+
+  if p_timeout is not null then
+    if p_timeout < 0 then
+      raise exception 'timeout must be non-negative';
+    end if;
+    v_timeout_at := v_now + (p_timeout::double precision * interval '1 second');
+  end if;
+
+  v_available_at := coalesce(v_timeout_at, 'infinity'::timestamptz);
+
+  execute format(
+    'select state, status
+       from absurd.%I
+      where task_id = $1
+        and checkpoint_name = $2',
+    'c_' || p_queue_name
+  )
+  into v_checkpoint_payload, v_checkpoint_status
+  using p_task_id, p_step_name;
+
+  if v_checkpoint_status is not null then
+    if v_checkpoint_status = 'timed_out' then
+      return query select false, null::jsonb, true;
+      return;
+    end if;
+    return query select false, v_checkpoint_payload, false;
+    return;
+  end if;
+
+  -- Ensure a row exists for this event so we can take a row-level lock.
+  --
+  -- We use payload IS NULL as the sentinel for "not emitted yet".  emit_event
+  -- always writes a non-NULL payload (at minimum JSON null).
+  --
+  -- Lock ordering is important to avoid deadlocks: await_event locks the event
+  -- row first (FOR SHARE) and then the run row (FOR UPDATE).  emit_event
+  -- naturally locks the event row via its UPSERT before touching waits/runs.
+  execute format(
+    'insert into absurd.%I (event_name, payload, emitted_at)
+     values ($1, null, ''epoch''::timestamptz)
+     on conflict (event_name) do nothing',
+    'e_' || p_queue_name
+  ) using p_event_name;
+
+  execute format(
+    'select 1
+       from absurd.%I
+      where event_name = $1
+      for share',
+    'e_' || p_queue_name
+  ) using p_event_name;
+
+  execute format(
+    'select r.state, r.event_payload, r.wake_event, t.state
+       from absurd.%I r
+       join absurd.%I t on t.task_id = r.task_id
+      where r.run_id = $1
+      for update',
+    'r_' || p_queue_name,
+    't_' || p_queue_name
+  )
+  into v_run_state, v_existing_payload, v_wake_event, v_task_state
+  using p_run_id;
+
+  if v_run_state is null then
+    raise exception 'Run "%" not found while awaiting event', p_run_id;
+  end if;
+
+  if v_task_state = 'cancelled' then
+    raise exception sqlstate 'AB001' using message = 'Task has been cancelled';
+  end if;
+
+  execute format(
+    'select payload
+       from absurd.%I
+      where event_name = $1',
+    'e_' || p_queue_name
+  )
+  into v_event_payload
+  using p_event_name;
+
+  if v_existing_payload is not null then
+    execute format(
+      'update absurd.%I
+          set event_payload = null
+        where run_id = $1',
+      'r_' || p_queue_name
+    ) using p_run_id;
+
+    if v_event_payload is not null and v_event_payload = v_existing_payload then
+      v_resolved_payload := v_existing_payload;
+    end if;
+  end if;
+
+  if v_run_state <> 'running' then
+    raise exception 'Run "%" must be running to await events', p_run_id;
+  end if;
+
+  if v_resolved_payload is null and v_event_payload is not null then
+    v_resolved_payload := v_event_payload;
+  end if;
+
+  if v_resolved_payload is not null then
+    execute format(
+      'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+       values ($1, $2, $3, ''committed'', $4, $5)
+       on conflict (task_id, checkpoint_name)
+       do update set state = excluded.state,
+                     status = excluded.status,
+                     owner_run_id = excluded.owner_run_id,
+                     updated_at = excluded.updated_at',
+      'c_' || p_queue_name
+    ) using p_task_id, p_step_name, v_resolved_payload, p_run_id, v_now;
+    return query select false, v_resolved_payload, false;
+    return;
+  end if;
+
+  -- Detect if we resumed due to timeout: wake_event matches and payload is null
+  if v_resolved_payload is null and v_wake_event = p_event_name and v_existing_payload is null then
+    -- Resumed due to timeout; persist timeout checkpoint and don't re-sleep.
+    execute format(
+      'insert into absurd.%I (task_id, checkpoint_name, state, status, owner_run_id, updated_at)
+       values ($1, $2, null, ''timed_out'', $3, $4)
+       on conflict (task_id, checkpoint_name)
+       do update set state = excluded.state,
+                     status = excluded.status,
+                     owner_run_id = excluded.owner_run_id,
+                     updated_at = excluded.updated_at',
+      'c_' || p_queue_name
+    ) using p_task_id, p_step_name, p_run_id, v_now;
+
+    execute format(
+      'update absurd.%I set wake_event = null where run_id = $1',
+      'r_' || p_queue_name
+    ) using p_run_id;
+    return query select false, null::jsonb, true;
+    return;
+  end if;
+
+  execute format(
+    'insert into absurd.%I (task_id, run_id, step_name, event_name, timeout_at, created_at)
+     values ($1, $2, $3, $4, $5, $6)
+     on conflict (run_id, step_name)
+     do update set event_name = excluded.event_name,
+                   timeout_at = excluded.timeout_at,
+                   created_at = excluded.created_at',
+    'w_' || p_queue_name
+  ) using p_task_id, p_run_id, p_step_name, p_event_name, v_timeout_at, v_now;
+
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping'',
+            claimed_by = null,
+            claim_expires_at = null,
+            available_at = $3,
+            wake_event = $2,
+            event_payload = null
+      where run_id = $1',
+    'r_' || p_queue_name
+  ) using p_run_id, p_event_name, v_available_at;
+
+  execute format(
+    'update absurd.%I
+        set state = ''sleeping''
+      where task_id = $1',
+    't_' || p_queue_name
+  ) using p_task_id;
+
+  return query select true, null::jsonb, false;
+  return;
+end;
+$$;
+
 create or replace function absurd.complete_run (
   p_queue_name text,
   p_run_id uuid,


### PR DESCRIPTION
Fixes durable `await_event` timeout handling across SQL and all SDKs.

- Adds an explicit `timed_out` return column to `absurd.await_event` so timeouts are no longer inferred from `payload = null`.
- Persists event timeouts as `timed_out` checkpoints, allowing timeout progress to replay durably instead of re-sleeping or repeating earlier work.
- Updates the Python, TypeScript, and Go SDKs to consume the new result shape while preserving compatibility with older two-column `await_event` implementations.
- Ensures cancellation is checked before replaying a persisted timeout, so cancellation is not masked by a previous timeout.

Previously, timeout detection relied on a legacy sentinel shape: `should_suspend = false` and `payload = null`. That made real JSON `null` event payloads ambiguous and meant timeout progress was not durably checkpointed in the same way as successful event payloads.