### PR TITLE
Make readonly ClaimedTask and queueName publicly accessible in TaskContext

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -265,6 +265,7 @@ export class TaskContext {
   private stepNameCounter: Map<string, number> = new Map();
   private readonly log: Log;
   readonly taskID: string;
+  readonly runID: string;
   private readonly con: Queryable;
   readonly queueName: string;
   readonly task: ClaimedTask;
@@ -284,6 +285,7 @@ export class TaskContext {
   ) {
     this.log = log;
     this.taskID = taskID;
+    this.runID = task.run_id;
     this.con = con;
     this.queueName = queueName;
     this.task = task;

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -266,8 +266,8 @@ export class TaskContext {
   private readonly log: Log;
   readonly taskID: string;
   private readonly con: Queryable;
-  private readonly queueName: string;
-  private readonly task: ClaimedTask;
+  readonly queueName: string;
+  readonly task: ClaimedTask;
   private readonly checkpointCache: Map<string, JsonValue>;
   private readonly claimTimeout: number;
   private readonly onLeaseExtended: (leaseSeconds: number) => void;


### PR DESCRIPTION
I think these are useful task metadata (i.e. run_id, task_id) which should be made accessible to the task execution handler.

Example production use case: Logging – correlating current run logs with run_id (instead of only task_id)

(Personal) Example test/demo use cases: Familiarizing with the task retry mechanism; Modify [demo code](https://github.com/earendil-works/absurd/blob/1b37c337307ebacd089fa71021982880966b035d/sdks/typescript/examples/quickstart/worker.ts#L29-L39) to "fake successful result" on 3rd run.

Resolves https://github.com/earendil-works/absurd/issues/113

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
