### PR TITLE
Add --target option to absurdctl schema-version

### DIFF
--- a/absurdctl
+++ b/absurdctl
@@ -1619,17 +1619,28 @@ def cmd_schema_version(args):
     """Show the currently recorded Absurd schema version."""
     usage = "usage: %prog schema-version [options]"
     parser = build_command_parser(usage)
+    parser.add_option(
+        "--target",
+        dest="target",
+        action="store_true",
+        default=False,
+        help="Print the latest schema version supported by this absurdctl",
+    )
 
     options, args = parse_args_with_help(
         parser,
         args,
-        ["absurdctl schema-version"],
+        ["absurdctl schema-version", "absurdctl schema-version --target"],
     )
 
     if args:
         print("Error: schema-version does not accept positional arguments", file=sys.stderr)
         parser.print_help()
         sys.exit(1)
+
+    if options.target:
+        print(ABSURD_SCHEMA_TARGET_VERSION)
+        return
 
     config = config_from_options(options)
     version = get_recorded_schema_version(config)


### PR DESCRIPTION
Add --target option to absurdctl schema-version that prints the value of ABSURD_SCHEMA_TARGET_VERSION

This is useful in order to generate a filename to dump the output of `absurdctl migrate` into.

**I used Claude code AI to generate this commit: I asked it to add a --target option for absurdctl schema-version that will print ABSURD_SCHEMA_TARGET_VERSION.**  I wrote the commit message myself, and I've manually reviewed the resulting change for correctness. I also manually ran the "Example usage" cases included for below for illustration.

Example usage:
```
$ ./absurdctl schema-version
0.2.0
$ ./absurdctl schema-version --target
main
$ ./absurdctl schema-version --help
Usage: absurdctl schema-version [options]

Options:
  -h HOST, --host=HOST  Database host
  -p PORT, --port=PORT  Database port
  -U USER, --user=USER  Database user
  -d DB, --database=DB  Database name or PostgreSQL connection URI
  -v, --verbose         Verbose output
  --help                Show this help message
  --target              Print the latest schema version supported by this absurdctl

Examples:
  absurdctl schema-version
  absurdctl schema-version --target
```

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

  - Acknowledged. See above note on AI use.

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
