### PR TITLE
absurdctl migrate: Make --from optional

### DIFF
--- a/absurdctl
+++ b/absurdctl
@@ -1689,21 +1689,14 @@ def cmd_migrate(args):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     target_version = options.to_version or ABSURD_SCHEMA_TARGET_VERSION
 
-    if options.dump_sql and options.from_version is None:
-        print(
-            "Error: --dump-sql requires --from VERSION so SQL can be generated from an explicit range.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     config = None
     from_version_supplied = options.from_version is not None
 
-    if options.dump_sql:
+    if from_version_supplied:
         current_version = options.from_version
     else:
         config = config_from_options(options)
-        current_version = options.from_version or get_recorded_schema_version(config)
+        current_version = get_recorded_schema_version(config)
 
     if current_version is None:
         print(


### PR DESCRIPTION
`absurdctl migrate`: Make `--from` optional.

This makes it consistent with the option's help text, which already read:

"Source schema version (overrides value recorded in DB)"

implying optionality.

**I used Claude code AI to generate this commit: I pointed out that the help text implied optionality, and asked it to make the parameter optional.** I manually reviewed the code for correctness, and I manually wrote the commit message and this PR description.

After this commit, the following command works:

`absurdctl migrate --dump-sql`

The versions migrated from or to can be observed from the last line of output, for example:

`-- end migration: 0.3.0-main.sql`

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

 - Acknowledged. Please note I used AI support, see above.

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
