### PR TITLE
feature/issue-31-docker-compose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,11 @@ jobs:
           mkdir -p bin
           go build -o bin/habitat ./cmd/habitat
 
+      - name: Build Habitat image
+        working-directory: habitat
+        run: |
+          docker build -t habitat:latest .
+
       - name: Create artifact name
         id: artifact
         run: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+services:
+  postgres:
+    image: postgres:18.3
+    environment:
+      POSTGRES_DB: absurd
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./sql/absurd.sql:/docker-entrypoint-initdb.d/001-absurd.sql:ro
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres -d absurd" ]
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  habitat:
+    image: habitat:latest
+    build:
+      context: ./habitat
+    ports:
+      - "7890:7890"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      HABITAT_DB_HOST: postgres
+      HABITAT_DB_USER: postgres
+      HABITAT_DB_PASSWORD: password
+      HABITAT_DB_SSLMODE: disable

--- a/habitat/.dockerignore
+++ b/habitat/.dockerignore
@@ -1,0 +1,7 @@
+*.pid
+*.log
+./habitat
+internal/web/dist/
+ui/.vite
+bin
+Dockerfile

--- a/habitat/Dockerfile
+++ b/habitat/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:12.13-slim AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+  apt-get update -y \
+  && apt-get install -y make curl build-essential
+
+RUN \
+  apt-get update && \
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+  apt-get install -y --no-install-recommends nodejs
+
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates && \
+  echo "deb http://deb.debian.org/debian bookworm-backports main" \
+    > /etc/apt/sources.list.d/bookworm-backports.list && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends -t bookworm-backports golang-go golang-1.23-go
+
+COPY . .
+
+RUN make build
+
+FROM debian:12.13-slim
+
+COPY --from=build bin/habitat /bin/habitat
+
+EXPOSE 7890
+ENTRYPOINT [ "/bin/habitat" ]
+CMD [ "run" ]

--- a/habitat/Makefile
+++ b/habitat/Makefile
@@ -5,7 +5,7 @@ UI_DIR := $(ROOT)/ui
 DIST_DIR := $(ROOT)/internal/web/dist
 BINARY := habitat
 
-.PHONY: dev build build-ui build-backend clean tidy fmt
+.PHONY: dev build build-ui build-backend build-docker clean tidy fmt
 
 dev: $(DIST_DIR) ## Run backend (with auto-reload) and UI dev server via shoreman
 	./scripts/shoreman.sh Procfile
@@ -25,6 +25,9 @@ build-ui: ## Compile the Solid dashboard bundle
 build-backend: ## Build the Habitat dashboard server binary
 	@mkdir -p $(BIN_DIR)
 	cd $(ROOT) && go build -o $(BIN_DIR)/$(BINARY) ./cmd/habitat
+
+build-docker: ## Build the Docker image
+	docker build -t habitat:latest .
 
 fmt: ## Format Go sources
 	cd $(ROOT) && gofmt -w $$(find . -name '*.go' -not -path './node_modules/*')


### PR DESCRIPTION
 - Adds Habitat Docker image
 - Adds Docker Compose definitions for local testing

First steps towards https://github.com/earendil-works/absurd/issues/31

AI Disclosure: I asked ChatGPT about Debian Backports. No other AI use. 

## Contribution Agreement

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
