### PR TITLE
fix(python-sdk): use default_max_attempts when registration has none

### DIFF
--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -1265,23 +1265,21 @@ class _AbsurdBase:
         else:
             actual_queue = queue
 
-        effective_max_attempts = (
-            max_attempts
-            if max_attempts is not None
-            else (
-                registration.get("default_max_attempts")
-                if registration
-                else self._default_max_attempts
-            )
+        registered_max_attempts = (
+            registration.get("default_max_attempts") if registration else None
         )
+        effective_max_attempts = max_attempts
+        if effective_max_attempts is None:
+            effective_max_attempts = registered_max_attempts
+        if effective_max_attempts is None:
+            effective_max_attempts = self._default_max_attempts
 
-        effective_cancellation = (
-            cancellation
-            if cancellation is not None
-            else registration.get("default_cancellation")
-            if registration
-            else None
+        registered_cancellation = (
+            registration.get("default_cancellation") if registration else None
         )
+        effective_cancellation = cancellation
+        if effective_cancellation is None:
+            effective_cancellation = registered_cancellation
 
         actual_queue = _validate_queue_name(actual_queue)
 

--- a/sdks/python/tests/test_retry.py
+++ b/sdks/python/tests/test_retry.py
@@ -23,7 +23,7 @@ def _set_fake_now(conn, fake_time):
 def _get_task(conn, queue, task_id):
     """Get task details"""
     query = sql.SQL(
-        "select state, attempts, completed_payload, cancelled_at from absurd.{table} where task_id = %s"
+        "select state, attempts, completed_payload, cancelled_at, max_attempts from absurd.{table} where task_id = %s"
     ).format(table=sql.Identifier(f"t_{queue}"))
     result = conn.execute(query, (task_id,)).fetchone()
     if not result:
@@ -33,6 +33,7 @@ def _get_task(conn, queue, task_id):
         "attempts": result[1],
         "completed_payload": result[2],
         "cancelled_at": result[3],
+        "max_attempts": result[4],
     }
 
 
@@ -187,6 +188,30 @@ def test_task_fails_permanently_after_max_attempts(conn, queue_name):
     assert task["state"] == "pending"
 
     # Attempt 2 (final)
+    client.work_batch("worker1", 60, 1)
+    task = _get_task(conn, queue, spawned["task_id"])
+    assert task["state"] == "failed"
+    assert task["attempts"] == 2
+
+
+def test_registered_task_without_retry_default_uses_client_default(conn, queue_name):
+    queue = queue_name("client_retry_default")
+    client = Absurd(conn, queue_name=queue, default_max_attempts=2)
+    client.create_queue()
+
+    @client.register_task("uses-client-default")
+    def uses_client_default(params, ctx):
+        raise Exception("always fails")
+
+    spawned = client.spawn("uses-client-default", None)
+
+    task = _get_task(conn, queue, spawned["task_id"])
+    assert task["max_attempts"] == 2
+
+    client.work_batch("worker1", 60, 1)
+    task = _get_task(conn, queue, spawned["task_id"])
+    assert task["state"] == "pending"
+
     client.work_batch("worker1", 60, 1)
     task = _get_task(conn, queue, spawned["task_id"])
     assert task["state"] == "failed"


### PR DESCRIPTION
When a registration did not provide the `default_max_attempts` property, and no `max_attempts` was passed at spawn time the python-sdk defaulted to unlimited intead of `default_max_attempts`. The `effective_cancellation` resolution did not have this bug, but I rewrote it in the same style for consistency.

## AI Disclosure

Claude Code assisted in tracking down the issue (after I noticed it in a project using the library), comparing the logic across SDKs to confirm the intended behavior, applying the fix, and adding a regression test.

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
