### PR TITLE
feat(sql): add declarative cron job registry

### DIFF
--- a/docs/patterns/cron.md
+++ b/docs/patterns/cron.md
@@ -215,3 +215,136 @@ select cron.schedule(
   $$
 );
 ```
+
+
+## Absurd Cron Job Registry
+
+For schedules that should live with Absurd itself, use the declarative cron job
+registry.  The registry keeps the schedule, target queue, target task, params,
+and task options in `absurd.cron_jobs`.  `pg_cron` remains optional: when it is
+available, it is an adapter that calls `absurd.run_cron_job(...)` for a registry
+row.
+
+This gives agents and operators a single Absurd-owned catalog to inspect without
+making `cron.job` the source of truth.
+
+```sql
+select *
+from absurd.register_cron_job(
+  p_job_name => 'daily-report',
+  p_queue_name => 'default',
+  p_task_name => 'send-report',
+  p_schedule => '0 8 * * *',
+  p_params => '{"kind":"daily"}'::jsonb,
+  p_task_options => '{"headers":{"owner":"ops"}}'::jsonb,
+  p_description => 'Send the daily report',
+  p_metadata => '{"team":"growth"}'::jsonb
+);
+```
+
+To execute a due slot from an application-side scheduler:
+
+```sql
+select * from absurd.run_cron_job('daily-report');
+```
+
+`run_cron_job` derives an idempotency key from the job name and UTC minute slot,
+then calls `spawn_task`.  Running the same job twice in the same minute returns
+the same task instead of duplicating work.
+
+If `pg_cron` is installed, Absurd can install, replace, and uninstall the adapter
+job for you:
+
+```sql
+-- Register and install in one call.
+select *
+from absurd.register_cron_job(
+  'daily-report',
+  'default',
+  'send-report',
+  '0 8 * * *',
+  '{"kind":"daily"}'::jsonb,
+  '{}'::jsonb,
+  true,
+  'Send the daily report',
+  '{}'::jsonb,
+  true
+);
+
+-- Or install/uninstall separately.
+select * from absurd.install_cron_job('daily-report');
+select * from absurd.uninstall_cron_job('daily-report');
+select * from absurd.unregister_cron_job('daily-report');
+```
+
+### Registry Shape
+
+`absurd.cron_jobs` contains:
+
+- `job_name` — stable logical name and primary key.
+- `queue_name` — target Absurd queue; cascades when the queue is dropped.
+- `task_name` — task to spawn.
+- `schedule` — cron expression (validated by the scheduler adapter when
+  installed).
+- `params` — JSON object passed to the task unchanged.
+- `task_options` — JSON object passed to `spawn_task`, except
+  `idempotency_key` is forbidden because Absurd derives it per schedule slot.
+- `enabled` — disabled jobs remain cataloged but `run_cron_job` does not spawn.
+- `description` and `metadata` — operator/agent-readable context.
+- `pgcron_job_id` — last installed `pg_cron` adapter job ID, when installed.
+
+`run_cron_job` adds scheduling context to spawn headers instead of mutating task
+params:
+
+- `absurd_cron_job`
+- `absurd_cron_schedule`
+- `absurd_cron_scheduled_for`
+
+### Adversarial Design Notes
+
+The registry is deliberately a small **module** with a narrow **interface**:
+register a schedule, install an optional adapter, run a due slot, and unregister
+it.  The implementation hides the messy parts that would otherwise leak to every
+caller.
+
+Important failure modes and mitigations:
+
+1. **Duplicate scheduler runs** — multiple scheduler processes or overlapping
+   `pg_cron` executions can call `run_cron_job` for the same UTC minute.  The
+   derived idempotency key collapses those calls into one task.
+2. **Registry/adapter drift** — `pg_cron` is treated as an adapter, not source of
+   truth.  Reinstalling a job unschedules existing adapter rows with the same
+   deterministic adapter name before scheduling the replacement.
+3. **Command injection** — `install_cron_job` quotes the logical job name when it
+   builds the adapter command.
+4. **User-controlled idempotency** — registry task options reject
+   `idempotency_key`; otherwise one schedule could accidentally suppress another
+   slot forever.
+5. **Queue deletion** — `drop_queue` unregisters queue-scoped cron jobs before
+   deleting queue tables, avoiding orphaned `pg_cron` jobs that fail forever.
+6. **Scheduler portability** — application-side schedulers can call
+   `run_cron_job`; Postgres-side schedulers can use `install_cron_job`.  The
+   registry does not require `pg_cron` to exist.
+7. **Cron expression validation** — plain Postgres does not parse cron syntax.
+   Application-side schedulers should validate expressions before calling the
+   registry; `pg_cron` installations validate by attempting `cron.schedule`.
+
+### Candidate Jobs From a Dexter/Hermes Audit
+
+The following operator-specific jobs were identified while designing the
+registry.  They are **candidates for registry rows**, not defaults installed by
+Absurd:
+
+| Job | Schedule | Target task idea | Notes |
+| --- | --- | --- | --- |
+| Daily Sentry top unresolved one-shot | `0 7 * * *` | `diggy.sentry.top-unresolved-one-shot` | Triage the highest-frequency unresolved Diggy Sentry issue and start the one-shot remediation workflow. |
+| Diggy weekly mining news to second brain | `0 8 * * 1` | `diggy.marketing.weekly-mining-news` | Collect weekly mining/field-ops news into the Diggy second brain. |
+| Diggy prod daily usability analysis report | `0 8 * * *` | `diggy.prod.usability-analysis` | Produce anonymized production usability insights from PostHog/Sentry. |
+| Daily architecture improvement with Effect best practices | `0 9 * * *` | `diggy.architecture.daily-review` | Run a read-only architecture review using the local Effect source. |
+| CMO blog implementation shepherd watchdog | `every 10m` | `diggy.workstream.shepherd` | Temporary bounded workstream watchdog. Convert to cron syntax if persisted in Postgres. |
+| DIG-5234 auth bootstrap one-shot watchdog | `every 10m` | `diggy.one-shot.watchdog` | Temporary bounded watchdog for a Diggy one-shot. |
+| DIG-5236 asset detail one-shot watchdog | `every 15m` | `diggy.one-shot.watchdog` | Temporary bounded watchdog for a Diggy one-shot. |
+| Diggy P0/P1 performance architecture shepherd | `every 15m` | `diggy.performance.shepherd` | Temporary bounded shepherd for performance work. |
+| Diggy performance PR adversarial merge/deploy shepherd | `every 10m` | `diggy.pr.merge-deploy-shepherd` | Temporary bounded PR/deploy shepherd. |
+| Absurd queued/running task monitor | operator-defined | `absurd.ops.task-monitor` | Mentioned as a useful monitor for queued/running Absurd tasks. |
+| Scheduled/autonomous Sentry remediation | operator-defined | `diggy.sentry.autonomous-remediation` | Broader recurring remediation idea; the daily top unresolved job is the concrete instance. |

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -74,6 +74,406 @@ create table if not exists absurd.queues (
     check (detach_min_age >= interval '0 seconds')
 );
 
+-- Declarative cron job registry for task-spawning schedules.
+--
+-- The registry is intentionally separate from pg_cron's cron.job table.  It is
+-- the Absurd-owned source of truth for "this schedule should spawn this task";
+-- pg_cron, when installed, is only an adapter that calls absurd.run_cron_job.
+create table if not exists absurd.cron_jobs (
+  job_name text primary key,
+  queue_name text not null references absurd.queues(queue_name) on delete cascade,
+  task_name text not null,
+  schedule text not null,
+  params jsonb not null default '{}'::jsonb,
+  task_options jsonb not null default '{}'::jsonb,
+  enabled boolean not null default true,
+  description text,
+  metadata jsonb not null default '{}'::jsonb,
+  pgcron_job_id bigint,
+  created_at timestamptz not null default absurd.current_time(),
+  updated_at timestamptz not null default absurd.current_time(),
+  check (length(trim(job_name)) > 0),
+  check (length(trim(queue_name)) > 0),
+  check (length(trim(task_name)) > 0),
+  check (length(trim(schedule)) > 0),
+  check (jsonb_typeof(params) = 'object'),
+  check (jsonb_typeof(task_options) = 'object'),
+  check (not (task_options ? 'idempotency_key')),
+  check (not (task_options ? 'headers') or jsonb_typeof(task_options->'headers') = 'object'),
+  check (jsonb_typeof(metadata) = 'object')
+);
+
+create index if not exists cron_jobs_queue_name_idx
+  on absurd.cron_jobs (queue_name);
+
+create function absurd.cron_job_slot (
+  p_scheduled_at timestamptz
+)
+  returns text
+  language sql
+  stable
+as $$
+  select to_char(
+    date_trunc('minute', coalesce(p_scheduled_at, absurd.current_time()) at time zone 'UTC'),
+    'YYYY-MM-DD"T"HH24:MI"Z"'
+  );
+$$;
+
+create function absurd.cron_job_idempotency_key (
+  p_job_name text,
+  p_scheduled_at timestamptz
+)
+  returns text
+  language sql
+  stable
+as $$
+  select 'cron:' || substr(md5(p_job_name || '|' || absurd.cron_job_slot(p_scheduled_at)), 1, 24);
+$$;
+
+create function absurd.cron_pgcron_job_name (
+  p_job_name text
+)
+  returns text
+  language sql
+  immutable
+as $$
+  select 'absurd_cron_' || substr(md5(p_job_name), 1, 24);
+$$;
+
+create function absurd.run_cron_job (
+  p_job_name text,
+  p_scheduled_at timestamptz default null
+)
+  returns table (
+    task_id uuid,
+    run_id uuid,
+    attempt integer,
+    created boolean
+  )
+  language plpgsql
+as $$
+declare
+  v_job absurd.cron_jobs%rowtype;
+  v_scheduled_at timestamptz := coalesce(p_scheduled_at, absurd.current_time());
+  v_headers jsonb;
+  v_options jsonb;
+begin
+  select *
+    into v_job
+    from absurd.cron_jobs
+   where job_name = p_job_name
+   for key share;
+
+  if not found then
+    raise exception 'Cron job "%" does not exist', p_job_name;
+  end if;
+
+  if not v_job.enabled then
+    return;
+  end if;
+
+  v_headers := coalesce(v_job.task_options->'headers', '{}'::jsonb)
+    || jsonb_build_object(
+      'absurd_cron_job', v_job.job_name,
+      'absurd_cron_schedule', v_job.schedule,
+      'absurd_cron_scheduled_for', absurd.cron_job_slot(v_scheduled_at)
+    );
+
+  v_options := v_job.task_options
+    || jsonb_build_object(
+      'headers', v_headers,
+      'idempotency_key', absurd.cron_job_idempotency_key(v_job.job_name, v_scheduled_at)
+    );
+
+  return query
+    select *
+      from absurd.spawn_task(
+        v_job.queue_name,
+        v_job.task_name,
+        v_job.params,
+        v_options
+      );
+end;
+$$;
+
+create function absurd.register_cron_job (
+  p_job_name text,
+  p_queue_name text,
+  p_task_name text,
+  p_schedule text,
+  p_params jsonb default '{}'::jsonb,
+  p_task_options jsonb default '{}'::jsonb,
+  p_enabled boolean default true,
+  p_description text default null,
+  p_metadata jsonb default '{}'::jsonb,
+  p_install_pgcron boolean default false
+)
+  returns table (
+    job_name text,
+    installed boolean,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_pgcron_job_id bigint;
+begin
+  if p_job_name is null or length(trim(p_job_name)) = 0 then
+    raise exception 'Cron job name must be provided';
+  end if;
+
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  if p_task_name is null or length(trim(p_task_name)) = 0 then
+    raise exception 'Task name must be provided';
+  end if;
+
+  if p_schedule is null or length(trim(p_schedule)) = 0 then
+    raise exception 'Cron schedule must be provided';
+  end if;
+
+  if coalesce(jsonb_typeof(coalesce(p_params, '{}'::jsonb)), '') <> 'object' then
+    raise exception 'Cron params must be a JSON object';
+  end if;
+
+  if coalesce(jsonb_typeof(coalesce(p_task_options, '{}'::jsonb)), '') <> 'object' then
+    raise exception 'Cron task_options must be a JSON object';
+  end if;
+
+  if coalesce(p_task_options, '{}'::jsonb) ? 'idempotency_key' then
+    raise exception 'Cron task_options must not include idempotency_key; Absurd derives one per schedule slot';
+  end if;
+
+  if coalesce(p_task_options, '{}'::jsonb) ? 'headers'
+     and jsonb_typeof(coalesce(p_task_options, '{}'::jsonb)->'headers') <> 'object' then
+    raise exception 'Cron task_options.headers must be a JSON object';
+  end if;
+
+  if coalesce(jsonb_typeof(coalesce(p_metadata, '{}'::jsonb)), '') <> 'object' then
+    raise exception 'Cron metadata must be a JSON object';
+  end if;
+
+  insert into absurd.cron_jobs (
+    job_name,
+    queue_name,
+    task_name,
+    schedule,
+    params,
+    task_options,
+    enabled,
+    description,
+    metadata,
+    updated_at
+  ) values (
+    p_job_name,
+    p_queue_name,
+    p_task_name,
+    p_schedule,
+    coalesce(p_params, '{}'::jsonb),
+    coalesce(p_task_options, '{}'::jsonb),
+    coalesce(p_enabled, true),
+    p_description,
+    coalesce(p_metadata, '{}'::jsonb),
+    absurd.current_time()
+  )
+  on conflict (job_name) do update
+     set queue_name = excluded.queue_name,
+         task_name = excluded.task_name,
+         schedule = excluded.schedule,
+         params = excluded.params,
+         task_options = excluded.task_options,
+         enabled = excluded.enabled,
+         description = excluded.description,
+         metadata = excluded.metadata,
+         updated_at = excluded.updated_at;
+
+  if p_install_pgcron then
+    select installed_job.pgcron_job_id
+      into v_pgcron_job_id
+      from absurd.install_cron_job(p_job_name) as installed_job;
+  else
+    select absurd.cron_jobs.pgcron_job_id
+      into v_pgcron_job_id
+      from absurd.cron_jobs
+     where absurd.cron_jobs.job_name = p_job_name;
+  end if;
+
+  job_name := p_job_name;
+  installed := p_install_pgcron;
+  pgcron_job_id := v_pgcron_job_id;
+  return next;
+end;
+$$;
+
+create function absurd.install_cron_job (
+  p_job_name text
+)
+  returns table (
+    job_name text,
+    pgcron_job_name text,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_job absurd.cron_jobs%rowtype;
+  v_pgcron_job_name text;
+  v_existing_job_id bigint;
+  v_job_id bigint;
+  v_command text;
+begin
+  select *
+    into v_job
+    from absurd.cron_jobs
+   where absurd.cron_jobs.job_name = p_job_name;
+
+  if not found then
+    raise exception 'Cron job "%" does not exist', p_job_name;
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_pgcron_job_name := absurd.cron_pgcron_job_name(p_job_name);
+  v_command := format('select * from absurd.run_cron_job(%L);', p_job_name);
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_pgcron_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_job_id
+    using v_pgcron_job_name, v_job.schedule, v_command;
+
+  update absurd.cron_jobs
+     set pgcron_job_id = v_job_id,
+         updated_at = absurd.current_time()
+   where absurd.cron_jobs.job_name = p_job_name;
+
+  job_name := p_job_name;
+  pgcron_job_name := v_pgcron_job_name;
+  pgcron_job_id := v_job_id;
+  return next;
+end;
+$$;
+
+create function absurd.uninstall_cron_job (
+  p_job_name text
+)
+  returns table (
+    job_name text,
+    pgcron_job_name text,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_pgcron_job_name text;
+  v_existing_job record;
+begin
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_pgcron_job_name := absurd.cron_pgcron_job_name(p_job_name);
+
+  for v_existing_job in
+    execute 'select jobid, jobname from cron.job where jobname = $1 order by jobid'
+    using v_pgcron_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job.jobid;
+
+    job_name := p_job_name;
+    pgcron_job_name := v_existing_job.jobname;
+    pgcron_job_id := v_existing_job.jobid;
+    return next;
+  end loop;
+
+  update absurd.cron_jobs
+     set pgcron_job_id = null,
+         updated_at = absurd.current_time()
+   where absurd.cron_jobs.job_name = p_job_name;
+end;
+$$;
+
+create function absurd.unregister_cron_job (
+  p_job_name text,
+  p_uninstall_pgcron boolean default true
+)
+  returns table (
+    job_name text,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_removed absurd.cron_jobs%rowtype;
+  v_uninstalled record;
+begin
+  if p_uninstall_pgcron
+     and to_regclass('cron.job') is not null
+     and exists (
+       select 1
+       from pg_proc p
+       join pg_namespace n on n.oid = p.pronamespace
+       where n.nspname = 'cron'
+         and p.proname = 'unschedule'
+     ) then
+    for v_uninstalled in
+      select * from absurd.uninstall_cron_job(p_job_name)
+    loop
+      job_name := v_uninstalled.job_name;
+      pgcron_job_id := v_uninstalled.pgcron_job_id;
+      return next;
+    end loop;
+  end if;
+
+  delete from absurd.cron_jobs
+   where absurd.cron_jobs.job_name = p_job_name
+   returning * into v_removed;
+
+  if found then
+    job_name := v_removed.job_name;
+    pgcron_job_id := v_removed.pgcron_job_id;
+    return next;
+  end if;
+end;
+$$;
+
 -- Returns the Absurd schema release version baked into this SQL file.
 -- During development this is usually "main" and release automation replaces
 -- it with the actual tag version.
@@ -353,6 +753,15 @@ begin
 
   if v_existing_queue is null then
     return;
+  end if;
+
+  -- Remove queue-scoped task-spawning cron adapters before the registry rows
+  -- cascade away.  Without this, pg_cron could retain orphaned jobs that fail
+  -- every time they call absurd.run_cron_job(...).
+  if to_regclass('absurd.cron_jobs') is not null then
+    perform absurd.unregister_cron_job(cj.job_name)
+      from absurd.cron_jobs cj
+     where cj.queue_name = p_queue_name;
   end if;
 
   -- Remove queue-scoped maintenance jobs only when pg_cron is available.

--- a/sql/migrations/0.3.0-main.sql
+++ b/sql/migrations/0.3.0-main.sql
@@ -398,6 +398,15 @@ begin
     return;
   end if;
 
+  -- Remove queue-scoped task-spawning cron adapters before the registry rows
+  -- cascade away.  Without this, pg_cron could retain orphaned jobs that fail
+  -- every time they call absurd.run_cron_job(...).
+  if to_regclass('absurd.cron_jobs') is not null then
+    perform absurd.unregister_cron_job(cj.job_name)
+      from absurd.cron_jobs cj
+     where cj.queue_name = p_queue_name;
+  end if;
+
   -- Remove queue-scoped maintenance jobs only when pg_cron is available.
   if to_regclass('cron.job') is not null and exists (
     select 1
@@ -1997,5 +2006,406 @@ begin
     job_id := v_existing_job.jobid;
     return next;
   end loop;
+end;
+$$;
+
+
+-- Declarative cron job registry for task-spawning schedules.
+--
+-- The registry is intentionally separate from pg_cron's cron.job table.  It is
+-- the Absurd-owned source of truth for "this schedule should spawn this task";
+-- pg_cron, when installed, is only an adapter that calls absurd.run_cron_job.
+create table if not exists absurd.cron_jobs (
+  job_name text primary key,
+  queue_name text not null references absurd.queues(queue_name) on delete cascade,
+  task_name text not null,
+  schedule text not null,
+  params jsonb not null default '{}'::jsonb,
+  task_options jsonb not null default '{}'::jsonb,
+  enabled boolean not null default true,
+  description text,
+  metadata jsonb not null default '{}'::jsonb,
+  pgcron_job_id bigint,
+  created_at timestamptz not null default absurd.current_time(),
+  updated_at timestamptz not null default absurd.current_time(),
+  check (length(trim(job_name)) > 0),
+  check (length(trim(queue_name)) > 0),
+  check (length(trim(task_name)) > 0),
+  check (length(trim(schedule)) > 0),
+  check (jsonb_typeof(params) = 'object'),
+  check (jsonb_typeof(task_options) = 'object'),
+  check (not (task_options ? 'idempotency_key')),
+  check (not (task_options ? 'headers') or jsonb_typeof(task_options->'headers') = 'object'),
+  check (jsonb_typeof(metadata) = 'object')
+);
+
+create index if not exists cron_jobs_queue_name_idx
+  on absurd.cron_jobs (queue_name);
+
+create or replace function absurd.cron_job_slot (
+  p_scheduled_at timestamptz
+)
+  returns text
+  language sql
+  stable
+as $$
+  select to_char(
+    date_trunc('minute', coalesce(p_scheduled_at, absurd.current_time()) at time zone 'UTC'),
+    'YYYY-MM-DD"T"HH24:MI"Z"'
+  );
+$$;
+
+create or replace function absurd.cron_job_idempotency_key (
+  p_job_name text,
+  p_scheduled_at timestamptz
+)
+  returns text
+  language sql
+  stable
+as $$
+  select 'cron:' || substr(md5(p_job_name || '|' || absurd.cron_job_slot(p_scheduled_at)), 1, 24);
+$$;
+
+create or replace function absurd.cron_pgcron_job_name (
+  p_job_name text
+)
+  returns text
+  language sql
+  immutable
+as $$
+  select 'absurd_cron_' || substr(md5(p_job_name), 1, 24);
+$$;
+
+create or replace function absurd.run_cron_job (
+  p_job_name text,
+  p_scheduled_at timestamptz default null
+)
+  returns table (
+    task_id uuid,
+    run_id uuid,
+    attempt integer,
+    created boolean
+  )
+  language plpgsql
+as $$
+declare
+  v_job absurd.cron_jobs%rowtype;
+  v_scheduled_at timestamptz := coalesce(p_scheduled_at, absurd.current_time());
+  v_headers jsonb;
+  v_options jsonb;
+begin
+  select *
+    into v_job
+    from absurd.cron_jobs
+   where job_name = p_job_name
+   for key share;
+
+  if not found then
+    raise exception 'Cron job "%" does not exist', p_job_name;
+  end if;
+
+  if not v_job.enabled then
+    return;
+  end if;
+
+  v_headers := coalesce(v_job.task_options->'headers', '{}'::jsonb)
+    || jsonb_build_object(
+      'absurd_cron_job', v_job.job_name,
+      'absurd_cron_schedule', v_job.schedule,
+      'absurd_cron_scheduled_for', absurd.cron_job_slot(v_scheduled_at)
+    );
+
+  v_options := v_job.task_options
+    || jsonb_build_object(
+      'headers', v_headers,
+      'idempotency_key', absurd.cron_job_idempotency_key(v_job.job_name, v_scheduled_at)
+    );
+
+  return query
+    select *
+      from absurd.spawn_task(
+        v_job.queue_name,
+        v_job.task_name,
+        v_job.params,
+        v_options
+      );
+end;
+$$;
+
+create or replace function absurd.register_cron_job (
+  p_job_name text,
+  p_queue_name text,
+  p_task_name text,
+  p_schedule text,
+  p_params jsonb default '{}'::jsonb,
+  p_task_options jsonb default '{}'::jsonb,
+  p_enabled boolean default true,
+  p_description text default null,
+  p_metadata jsonb default '{}'::jsonb,
+  p_install_pgcron boolean default false
+)
+  returns table (
+    job_name text,
+    installed boolean,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_pgcron_job_id bigint;
+begin
+  if p_job_name is null or length(trim(p_job_name)) = 0 then
+    raise exception 'Cron job name must be provided';
+  end if;
+
+  p_queue_name := absurd.validate_queue_name(p_queue_name);
+
+  if p_task_name is null or length(trim(p_task_name)) = 0 then
+    raise exception 'Task name must be provided';
+  end if;
+
+  if p_schedule is null or length(trim(p_schedule)) = 0 then
+    raise exception 'Cron schedule must be provided';
+  end if;
+
+  if coalesce(jsonb_typeof(coalesce(p_params, '{}'::jsonb)), '') <> 'object' then
+    raise exception 'Cron params must be a JSON object';
+  end if;
+
+  if coalesce(jsonb_typeof(coalesce(p_task_options, '{}'::jsonb)), '') <> 'object' then
+    raise exception 'Cron task_options must be a JSON object';
+  end if;
+
+  if coalesce(p_task_options, '{}'::jsonb) ? 'idempotency_key' then
+    raise exception 'Cron task_options must not include idempotency_key; Absurd derives one per schedule slot';
+  end if;
+
+  if coalesce(p_task_options, '{}'::jsonb) ? 'headers'
+     and jsonb_typeof(coalesce(p_task_options, '{}'::jsonb)->'headers') <> 'object' then
+    raise exception 'Cron task_options.headers must be a JSON object';
+  end if;
+
+  if coalesce(jsonb_typeof(coalesce(p_metadata, '{}'::jsonb)), '') <> 'object' then
+    raise exception 'Cron metadata must be a JSON object';
+  end if;
+
+  insert into absurd.cron_jobs (
+    job_name,
+    queue_name,
+    task_name,
+    schedule,
+    params,
+    task_options,
+    enabled,
+    description,
+    metadata,
+    updated_at
+  ) values (
+    p_job_name,
+    p_queue_name,
+    p_task_name,
+    p_schedule,
+    coalesce(p_params, '{}'::jsonb),
+    coalesce(p_task_options, '{}'::jsonb),
+    coalesce(p_enabled, true),
+    p_description,
+    coalesce(p_metadata, '{}'::jsonb),
+    absurd.current_time()
+  )
+  on conflict (job_name) do update
+     set queue_name = excluded.queue_name,
+         task_name = excluded.task_name,
+         schedule = excluded.schedule,
+         params = excluded.params,
+         task_options = excluded.task_options,
+         enabled = excluded.enabled,
+         description = excluded.description,
+         metadata = excluded.metadata,
+         updated_at = excluded.updated_at;
+
+  if p_install_pgcron then
+    select installed_job.pgcron_job_id
+      into v_pgcron_job_id
+      from absurd.install_cron_job(p_job_name) as installed_job;
+  else
+    select absurd.cron_jobs.pgcron_job_id
+      into v_pgcron_job_id
+      from absurd.cron_jobs
+     where absurd.cron_jobs.job_name = p_job_name;
+  end if;
+
+  job_name := p_job_name;
+  installed := p_install_pgcron;
+  pgcron_job_id := v_pgcron_job_id;
+  return next;
+end;
+$$;
+
+create or replace function absurd.install_cron_job (
+  p_job_name text
+)
+  returns table (
+    job_name text,
+    pgcron_job_name text,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_job absurd.cron_jobs%rowtype;
+  v_pgcron_job_name text;
+  v_existing_job_id bigint;
+  v_job_id bigint;
+  v_command text;
+begin
+  select *
+    into v_job
+    from absurd.cron_jobs
+   where absurd.cron_jobs.job_name = p_job_name;
+
+  if not found then
+    raise exception 'Cron job "%" does not exist', p_job_name;
+  end if;
+
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'schedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.schedule)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_pgcron_job_name := absurd.cron_pgcron_job_name(p_job_name);
+  v_command := format('select * from absurd.run_cron_job(%L);', p_job_name);
+
+  for v_existing_job_id in
+    execute 'select jobid from cron.job where jobname = $1'
+    using v_pgcron_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job_id;
+  end loop;
+
+  execute 'select cron.schedule($1, $2, $3)'
+    into v_job_id
+    using v_pgcron_job_name, v_job.schedule, v_command;
+
+  update absurd.cron_jobs
+     set pgcron_job_id = v_job_id,
+         updated_at = absurd.current_time()
+   where absurd.cron_jobs.job_name = p_job_name;
+
+  job_name := p_job_name;
+  pgcron_job_name := v_pgcron_job_name;
+  pgcron_job_id := v_job_id;
+  return next;
+end;
+$$;
+
+create or replace function absurd.uninstall_cron_job (
+  p_job_name text
+)
+  returns table (
+    job_name text,
+    pgcron_job_name text,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_pgcron_job_name text;
+  v_existing_job record;
+begin
+  if to_regclass('cron.job') is null then
+    raise exception 'pg_cron is not available (missing cron.job)';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'cron'
+      and p.proname = 'unschedule'
+  ) then
+    raise exception 'pg_cron is not available (missing cron.unschedule)';
+  end if;
+
+  v_pgcron_job_name := absurd.cron_pgcron_job_name(p_job_name);
+
+  for v_existing_job in
+    execute 'select jobid, jobname from cron.job where jobname = $1 order by jobid'
+    using v_pgcron_job_name
+  loop
+    execute 'select cron.unschedule($1)' using v_existing_job.jobid;
+
+    job_name := p_job_name;
+    pgcron_job_name := v_existing_job.jobname;
+    pgcron_job_id := v_existing_job.jobid;
+    return next;
+  end loop;
+
+  update absurd.cron_jobs
+     set pgcron_job_id = null,
+         updated_at = absurd.current_time()
+   where absurd.cron_jobs.job_name = p_job_name;
+end;
+$$;
+
+create or replace function absurd.unregister_cron_job (
+  p_job_name text,
+  p_uninstall_pgcron boolean default true
+)
+  returns table (
+    job_name text,
+    pgcron_job_id bigint
+  )
+  language plpgsql
+as $$
+declare
+  v_removed absurd.cron_jobs%rowtype;
+  v_uninstalled record;
+begin
+  if p_uninstall_pgcron
+     and to_regclass('cron.job') is not null
+     and exists (
+       select 1
+       from pg_proc p
+       join pg_namespace n on n.oid = p.pronamespace
+       where n.nspname = 'cron'
+         and p.proname = 'unschedule'
+     ) then
+    for v_uninstalled in
+      select * from absurd.uninstall_cron_job(p_job_name)
+    loop
+      job_name := v_uninstalled.job_name;
+      pgcron_job_id := v_uninstalled.pgcron_job_id;
+      return next;
+    end loop;
+  end if;
+
+  delete from absurd.cron_jobs
+   where absurd.cron_jobs.job_name = p_job_name
+   returning * into v_removed;
+
+  if found then
+    job_name := v_removed.job_name;
+    pgcron_job_id := v_removed.pgcron_job_id;
+    return next;
+  end if;
 end;
 $$;

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -457,3 +457,177 @@ def test_drop_queue_unschedules_queue_scoped_cron_jobs(client):
         (f"absurd%{scope}%",),
     ).fetchall()
     assert remaining == []
+
+
+
+def test_register_cron_job_records_declarative_schedule_and_runs_idempotently(client):
+    queue = "cron-registry-run"
+    client.create_queue(queue)
+    base = datetime(2024, 6, 1, 10, 3, 45, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+
+    row = client.conn.execute(
+        """
+        select job_name, installed, pgcron_job_id
+        from absurd.register_cron_job(
+          'daily-report',
+          %s,
+          'send-report',
+          '0 8 * * *',
+          '{"kind":"daily"}'::jsonb,
+          '{"headers":{"source":"test"}}'::jsonb,
+          true,
+          'Daily report',
+          '{"owner":"ops"}'::jsonb
+        )
+        """,
+        (queue,),
+    ).fetchone()
+
+    assert row == ("daily-report", False, None)
+
+    first = client.conn.execute(
+        "select task_id, run_id, attempt, created from absurd.run_cron_job('daily-report')"
+    ).fetchone()
+    second = client.conn.execute(
+        "select task_id, run_id, attempt, created from absurd.run_cron_job('daily-report')"
+    ).fetchone()
+
+    assert first is not None
+    assert first[3] is True
+    assert second is not None
+    assert second[0] == first[0]
+    assert second[1] == first[1]
+    assert second[3] is False
+
+    task = client.get_task(queue, first[0])
+    assert task is not None
+    assert task["task_name"] == "send-report"
+    assert task["params"] == {"kind": "daily"}
+    assert task["headers"]["source"] == "test"
+    assert task["headers"]["absurd_cron_job"] == "daily-report"
+    assert task["headers"]["absurd_cron_schedule"] == "0 8 * * *"
+    assert task["headers"]["absurd_cron_scheduled_for"] == "2024-06-01T10:03Z"
+
+
+def test_register_cron_job_can_install_replace_and_uninstall_pgcron_adapter(client):
+    queue = "cron-registry-pgcron"
+    client.create_queue(queue)
+    _install_mock_cron(client.conn)
+
+    installed = client.conn.execute(
+        """
+        select job_name, installed, pgcron_job_id
+        from absurd.register_cron_job(
+          'rebuild-search',
+          %s,
+          'rebuild-search-index',
+          '0 2 * * *',
+          '{}'::jsonb,
+          '{}'::jsonb,
+          true,
+          null,
+          '{}'::jsonb,
+          true
+        )
+        """,
+        (queue,),
+    ).fetchone()
+
+    assert installed[0] == "rebuild-search"
+    assert installed[1] is True
+    assert installed[2] is not None
+
+    jobs = client.conn.execute(
+        "select jobname, schedule, command from cron.job order by jobid"
+    ).fetchall()
+    assert len(jobs) == 1
+    assert jobs[0][0].startswith("absurd_cron_")
+    assert jobs[0][1] == "0 2 * * *"
+    assert "absurd.run_cron_job('rebuild-search')" in jobs[0][2]
+
+    client.conn.execute(
+        """
+        select *
+        from absurd.register_cron_job(
+          'rebuild-search',
+          %s,
+          'rebuild-search-index',
+          '30 2 * * *',
+          '{}'::jsonb,
+          '{}'::jsonb,
+          true,
+          null,
+          '{}'::jsonb,
+          true
+        )
+        """,
+        (queue,),
+    )
+
+    jobs_after_replace = client.conn.execute(
+        "select schedule, command from cron.job order by jobid"
+    ).fetchall()
+    assert jobs_after_replace == [("30 2 * * *", "select * from absurd.run_cron_job('rebuild-search');")]
+
+    removed = client.conn.execute(
+        "select job_name, pgcron_job_id from absurd.unregister_cron_job('rebuild-search')"
+    ).fetchall()
+    assert removed
+    assert client.conn.execute("select count(*) from cron.job").fetchone()[0] == 0
+    assert client.conn.execute("select count(*) from absurd.cron_jobs").fetchone()[0] == 0
+
+
+def test_cron_job_registry_rejects_user_supplied_idempotency_key(client):
+    queue = "cron-registry-idem"
+    client.create_queue(queue)
+
+    with pytest.raises(Exception):
+        client.conn.execute(
+            """
+            select *
+            from absurd.register_cron_job(
+              'bad-idempotency',
+              %s,
+              'task',
+              '* * * * *',
+              '{}'::jsonb,
+              '{"idempotency_key":"user-controlled"}'::jsonb
+            )
+            """,
+            (queue,),
+        )
+
+
+def test_drop_queue_unschedules_registered_cron_jobs(client):
+    queue = "cron-registry-drop"
+    client.create_queue(queue)
+    _install_mock_cron(client.conn)
+
+    client.conn.execute(
+        """
+        select *
+        from absurd.register_cron_job(
+          'drop-me',
+          %s,
+          'task',
+          '* * * * *',
+          '{}'::jsonb,
+          '{}'::jsonb,
+          true,
+          null,
+          '{}'::jsonb,
+          true
+        )
+        """,
+        (queue,),
+    )
+    assert client.conn.execute("select count(*) from cron.job").fetchone()[0] == 1
+
+    client.drop_queue(queue)
+
+    assert client.conn.execute("select count(*) from cron.job").fetchone()[0] == 0
+    assert client.conn.execute(
+        "select count(*) from absurd.cron_jobs where queue_name = %s",
+        (queue,),
+    ).fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- Add `absurd.cron_jobs` as an Absurd-owned registry for task-spawning schedules.
- Add registry functions for registering, running, installing/uninstalling pg_cron adapters, and unregistering jobs.
- Preserve idempotency per UTC minute slot and reject user-supplied cron idempotency keys.
- Unregister queue-scoped cron jobs during `drop_queue` to avoid orphaned pg_cron adapters.
- Document the architecture, adversarial failure modes, and operator-specific candidate jobs surfaced from Dexter/Hermes cron history.

## Test Plan
- `uv run --with pglast python - <<'PY' ... parse sql/absurd.sql and sql/migrations/0.3.0-main.sql ... PY`
- `cd tests && uv run python -m py_compile test_cron.py`
- Attempted: `cd tests && uv run pytest test_cron.py -q` — blocked because local Docker/OrbStack daemon returns EOF while testcontainers fetches `/version`.