### PR TITLE
fix(absurdctl): pass spawn options payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This contains the changes between releases.
 * Fixed the Python SDK's synchronous worker to honor configured `concurrency` and run tasks in parallel when `concurrency > 1`.
 * Improved Python SDK type annotations and hook handling for better static type-checking and async hook interoperability.
 * Fixed Go SDK spawn behavior to require an explicit queue when spawning unregistered tasks.
+* Fixed `absurdctl spawn-task` to pass headers, max attempts, retry strategy, and cancellation policy inside the SQL `spawn_task` options payload.
 
 # 0.3.0
 

--- a/absurdctl
+++ b/absurdctl
@@ -1944,7 +1944,7 @@ def cmd_spawn_task(args):
 
     params_json = build_json_params(options.params, options.base_params)
 
-    headers_payload = None
+    spawn_options = {}
     if options.headers:
         headers_dict = {}
         for header in options.headers:
@@ -1956,32 +1956,35 @@ def cmd_spawn_task(args):
                 sys.exit(1)
             key, value = header.split("=", 1)
             headers_dict[key] = value
-        headers_payload = json.dumps(headers_dict)
+        spawn_options["headers"] = headers_dict
 
-    retry_json = "NULL"
+    if options.max_attempts is not None:
+        spawn_options["max_attempts"] = options.max_attempts
+
     if (
         options.retry_kind
-        or options.retry_base
-        or options.retry_factor
-        or options.retry_max
+        or options.retry_base is not None
+        or options.retry_factor is not None
+        or options.retry_max is not None
     ):
         retry = {"kind": options.retry_kind or "exponential"}
-        if options.retry_base:
-            retry["baseSeconds"] = options.retry_base
-        if options.retry_factor:
+        if options.retry_base is not None:
+            retry["base_seconds"] = options.retry_base
+        if options.retry_factor is not None:
             retry["factor"] = options.retry_factor
-        if options.retry_max:
-            retry["maxSeconds"] = options.retry_max
-        retry_json = f"'{json.dumps(retry)}'::jsonb"
+        if options.retry_max is not None:
+            retry["max_seconds"] = options.retry_max
+        spawn_options["retry_strategy"] = retry
 
-    cancellation_json = "NULL"
-    if options.max_duration or options.max_delay:
+    if options.max_duration is not None or options.max_delay is not None:
         cancellation = {}
-        if options.max_duration:
-            cancellation["maxDuration"] = options.max_duration
-        if options.max_delay:
-            cancellation["maxDelay"] = options.max_delay
-        cancellation_json = f"'{json.dumps(cancellation)}'::jsonb"
+        if options.max_duration is not None:
+            cancellation["max_duration"] = options.max_duration
+        if options.max_delay is not None:
+            cancellation["max_delay"] = options.max_delay
+        spawn_options["cancellation"] = cancellation
+
+    options_payload = json.dumps(spawn_options)
 
     queue = validate_queue_name(options.queue or "default")
 
@@ -1992,34 +1995,31 @@ def cmd_spawn_task(args):
         ("Queue", queue),
         ("Params", params_json),
     ]
-    if headers_payload is not None:
-        details.append(("Headers", headers_payload))
-    if options.max_attempts:
-        details.append(("Max attempts", options.max_attempts))
-    if retry_json != "NULL":
-        details.append(("Retry strategy", retry_json))
-    if cancellation_json != "NULL":
-        details.append(("Cancellation", cancellation_json))
+    if "headers" in spawn_options:
+        details.append(("Headers", json.dumps(spawn_options["headers"])))
+    if "max_attempts" in spawn_options:
+        details.append(("Max attempts", spawn_options["max_attempts"]))
+    if "retry_strategy" in spawn_options:
+        details.append(("Retry strategy", json.dumps(spawn_options["retry_strategy"])))
+    if "cancellation" in spawn_options:
+        details.append(("Cancellation", json.dumps(spawn_options["cancellation"])))
     details.extend(get_common_db_details(config))
     print_verbose_configuration(options.verbose, details)
 
-    headers_expr = "NULL"
     variables = {
         "queue": queue,
         "task_name": task_name,
         "params_json": params_json,
+        "options_json": options_payload,
     }
-    if headers_payload is not None:
-        headers_expr = ":'headers_json'::jsonb"
-        variables["headers_json"] = headers_payload
 
-    query = f"""
+    query = """
         SELECT task_id, run_id, attempt
         FROM absurd.spawn_task(
             :'queue',
             :'task_name',
             :'params_json'::jsonb,
-            {headers_expr}
+            :'options_json'::jsonb
         );
     """
 

--- a/tests/test_absurdctl_validation.py
+++ b/tests/test_absurdctl_validation.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from subprocess import CompletedProcess
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ ABSURDCTL_PATH = Path(__file__).resolve().parents[1] / "absurdctl"
 MODULE = runpy.run_path(str(ABSURDCTL_PATH))
 validate_queue_name = MODULE["validate_queue_name"]
 cmd_emit_event = MODULE["cmd_emit_event"]
+cmd_spawn_task = MODULE["cmd_spawn_task"]
 cmd_retry_task = MODULE["cmd_retry_task"]
 cmd_migrate = MODULE["cmd_migrate"]
 cmd_schema_version = MODULE["cmd_schema_version"]
@@ -94,6 +96,139 @@ def test_emit_event_validates_queue_name(monkeypatch):
 
     with pytest.raises(SystemExit):
         cmd_emit_event(["-q", "a" * 58, "order.completed"])
+
+
+def test_spawn_task_passes_options_payload(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["query"] = query
+        captured["variables"] = kwargs.get("variables")
+        return [
+            [
+                "019a32d3-8425-7ae2-a5af-2f17a6707666",
+                "019a32d3-8425-7ae2-a5af-2f17a6707667",
+                "1",
+            ]
+        ]
+
+    monkeypatch.setitem(cmd_spawn_task.__globals__, "run_psql_csv", fake_run_psql_csv)
+    monkeypatch.setitem(
+        cmd_spawn_task.__globals__, "ensure_queue_exists", lambda *_: None
+    )
+
+    cmd_spawn_task(
+        [
+            "-q",
+            "default",
+            "my-task",
+            "--params",
+            '{"foo":"bar"}',
+            "-H",
+            "origin-kind=slack",
+            "--max-attempts",
+            "5",
+            "--retry-kind",
+            "fixed",
+            "--retry-base",
+            "10",
+            "--retry-max",
+            "60",
+            "--max-duration",
+            "300",
+            "--max-delay",
+            "30",
+        ]
+    )
+
+    assert ":'options_json'::jsonb" in captured["query"]
+    assert captured["variables"]["queue"] == "default"
+    assert captured["variables"]["task_name"] == "my-task"
+    assert captured["variables"]["params_json"] == '{"foo": "bar"}'
+    assert json.loads(captured["variables"]["options_json"]) == {
+        "headers": {"origin-kind": "slack"},
+        "max_attempts": 5,
+        "retry_strategy": {
+            "kind": "fixed",
+            "base_seconds": 10,
+            "max_seconds": 60,
+        },
+        "cancellation": {
+            "max_duration": 300,
+            "max_delay": 30,
+        },
+    }
+
+
+def test_spawn_task_preserves_zero_valued_options(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["variables"] = kwargs.get("variables")
+        return [
+            [
+                "019a32d3-8425-7ae2-a5af-2f17a6707666",
+                "019a32d3-8425-7ae2-a5af-2f17a6707667",
+                "1",
+            ]
+        ]
+
+    monkeypatch.setitem(cmd_spawn_task.__globals__, "run_psql_csv", fake_run_psql_csv)
+    monkeypatch.setitem(
+        cmd_spawn_task.__globals__, "ensure_queue_exists", lambda *_: None
+    )
+
+    cmd_spawn_task(
+        [
+            "my-task",
+            "--retry-base",
+            "0",
+            "--retry-factor",
+            "0",
+            "--retry-max",
+            "0",
+            "--max-duration",
+            "0",
+            "--max-delay",
+            "0",
+        ]
+    )
+
+    assert json.loads(captured["variables"]["options_json"]) == {
+        "retry_strategy": {
+            "kind": "exponential",
+            "base_seconds": 0,
+            "factor": 0.0,
+            "max_seconds": 0,
+        },
+        "cancellation": {
+            "max_duration": 0,
+            "max_delay": 0,
+        },
+    }
+
+
+def test_spawn_task_uses_empty_options_payload_by_default(monkeypatch):
+    captured = {}
+
+    def fake_run_psql_csv(config, query=None, **kwargs):
+        captured["variables"] = kwargs.get("variables")
+        return [
+            [
+                "019a32d3-8425-7ae2-a5af-2f17a6707666",
+                "019a32d3-8425-7ae2-a5af-2f17a6707667",
+                "1",
+            ]
+        ]
+
+    monkeypatch.setitem(cmd_spawn_task.__globals__, "run_psql_csv", fake_run_psql_csv)
+    monkeypatch.setitem(
+        cmd_spawn_task.__globals__, "ensure_queue_exists", lambda *_: None
+    )
+
+    cmd_spawn_task(["my-task"])
+
+    assert captured["variables"]["options_json"] == "{}"
 
 
 def test_retry_task_uses_parameterized_query(monkeypatch):


### PR DESCRIPTION
Wrap spawn-task CLI headers, retry, max-attempts, and cancellation fields in the SQL spawn_task options object instead of passing headers directly as the fourth argument. Use the snake_case option keys expected by the stored procedures and add regression coverage for the generated parameterized query.

## Summary

`absurdctl spawn-task` accepts CLI flags for headers, max attempts, retry strategy, and cancellation policy, but the SQL `absurd.spawn_task` function expects those fields inside a single JSON options object.

Before this change, `absurdctl` passed headers directly as the fourth argument and only displayed the other options in verbose output, so `--max-attempts`, `--retry-*`, `--max-duration`, and `--max-delay` were not persisted by spawned tasks.

This change:

- Builds one `spawn_options` JSON object for `headers`, `max_attempts`, `retry_strategy`, and `cancellation`.
- Passes that object as `:'options_json'::jsonb` to `absurd.spawn_task`.
- Uses the snake_case option keys expected by the stored procedures.
- Preserves explicit zero-valued retry/cancellation options.
- Adds regression tests for the generated parameterized query, zero-valued options, and the default empty-options case.
- Adds an Unreleased changelog entry.

## Test Plan

- `python3 -m py_compile absurdctl`
- `cd tests && uv run pytest test_absurdctl_validation.py`
- `make check`

## AI Disclosure

AI assistance was used to inspect the existing `absurdctl`/SQL option contract, implement the narrow fix, add regression tests, review open issues/PRs for overlap and maintainer expectations. The final diff and PR text were manually reviewed and validated.

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
