### PR TITLE
fix(sql): remove uuid-ossp requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This contains the changes between releases.
 
 # Unreleased
 
+* Removed the SQL dependency on `uuid-ossp`; UUIDv7 generation continues to use PostgreSQL's native UUIDv7 function when available and otherwise builds UUIDv7 values using PostgreSQL's built-in random UUID generator.
+
 # 0.4.0
 
 * Added a Go SDK.  #80

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -2224,13 +2224,12 @@ create function absurd.portable_uuidv7 ()
   volatile
 as $$
 declare
-  v_server_num integer := current_setting('server_version_num')::int;
   ts_ms bigint;
   b bytea;
   rnd bytea;
   i int;
 begin
-  if v_server_num >= 180000 and to_regproc('pg_catalog.uuidv7') is not null then
+  if to_regprocedure('pg_catalog.uuidv7()') is not null then
     return pg_catalog.uuidv7 ();
   end if;
   ts_ms := floor(extract(epoch from absurd.current_time()) * 1000)::bigint;

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -1,7 +1,7 @@
 -- Absurd installs a Postgres-native durable workflow system that can be dropped
 -- into an existing database.
 --
--- It bootstraps the `absurd` schema and required extensions so that jobs, runs,
+-- It bootstraps the `absurd` schema and database objects so that jobs, runs,
 -- checkpoints, and workflow events all live alongside application data without
 -- external services.
 --
@@ -29,8 +29,6 @@
 -- coordinate sleepers and external signals so that tasks can suspend and resume
 -- without losing context.  Events are uniquely indexed and use first-write-wins
 -- semantics: the first emission per name is cached, later emits are ignored.
-
-create extension if not exists "uuid-ossp";
 
 create schema if not exists absurd;
 
@@ -2232,11 +2230,11 @@ declare
   rnd bytea;
   i int;
 begin
-  if v_server_num >= 180000 then
-    return uuidv7 ();
+  if v_server_num >= 180000 and to_regproc('pg_catalog.uuidv7') is not null then
+    return pg_catalog.uuidv7 ();
   end if;
   ts_ms := floor(extract(epoch from absurd.current_time()) * 1000)::bigint;
-  rnd := uuid_send(uuid_generate_v4 ());
+  rnd := uuid_send(pg_catalog.gen_random_uuid ());
   b := repeat(E'\\000', 16)::bytea;
   for i in 0..5 loop
     b := set_byte(b, i, ((ts_ms >> ((5 - i) * 8)) & 255)::int);

--- a/tests/test_partition_utils.py
+++ b/tests/test_partition_utils.py
@@ -15,7 +15,7 @@ def test_uuidv7_timestamp_extracts_timestamp(client):
 
 def test_uuidv7_timestamp_returns_null_for_non_v7(client):
     row = client.conn.execute(
-        "select absurd.uuidv7_timestamp(uuid_generate_v4())"
+        "select absurd.uuidv7_timestamp(gen_random_uuid())"
     ).fetchone()
 
     assert row is not None


### PR DESCRIPTION
I am experimenting with absurd in pglite (postgres in wasm). I got absurd to load when I patched iti not to depend on `uuid-ossp`. While investigating why `uuid-ossp` is needed in absurd, I found that it ïs likely only there for compat reasons with older postgres versions. I dug deeper and came to the conclusion that `uuid-ossp` - if only used vor uuid v4 creation - should be entirely replaceable by `gen_random_uuid()`. This eliminates the hard dependency and makes absurd compatible with current pglite. Happy to get feedback whether that makes sense for the project.

**AI-Disclosure:**
* `uuid-ossp` blocking absurd of running in pglite was found by GPT 5.5, the solution of removing it was reviewed and iterated on multiple times by me, until I felt confident enough to have a reasonably small contribution for a PR
* All of the PR Description was written old-school by hand ;)

## Contribution Agreement

Please ensure this PR follows the guidelines in `CONTRIBUTING.md`.

<!-- Earendil employees and contractors can delete or ignore the following: -->

By submitting this pull request, I confirm the following:

I understand that the entity Earendil Inc. (incorporated in the state of Delaware in 2025) needs some rights from me in order to utilize my contributions in this PR.  As a contributor I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Earendil Inc. can use, modify, copy, and redistribute my contributions, under Earendil Inc.'s choice of terms.
