### PR TITLE
fix: cancellation large sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This contains the changes between releases.
 
 # Unreleased
 
+* Indexed and narrowed claim-time cancellation maintenance so worker polling avoids scanning large historical task tables for tasks without cancellation policies.
+
 # 0.5.0
 
 * Added a Habitat tasks filter for terminal failures and defaulted the failed status view to hide failed attempts that were retried later.

--- a/sql/absurd.sql
+++ b/sql/absurd.sql
@@ -332,6 +332,14 @@ begin
   );
 
   execute format(
+    'create index if not exists %I on absurd.%I (task_id)
+      where state in (''pending'', ''sleeping'', ''running'')
+        and cancellation is not null',
+    ('t_' || p_queue_name) || '_aci',
+    't_' || p_queue_name
+  );
+
+  execute format(
     'create index if not exists %I on absurd.%I (event_name)',
     ('w_' || p_queue_name) || '_eni',
     'w_' || p_queue_name
@@ -953,6 +961,7 @@ begin
       'select task_id
          from absurd.%I
         where state in (''pending'', ''sleeping'', ''running'')
+          and cancellation is not null
           and (
             (
               (cancellation->>''max_delay'')::bigint is not null

--- a/sql/migrations/0.5.0-main.sql
+++ b/sql/migrations/0.5.0-main.sql
@@ -1,0 +1,384 @@
+-- Migration from 0.5.0 to main
+--
+-- Narrow claim-time cancellation maintenance to tasks with cancellation policies
+-- and add the matching partial index for existing and future queues.
+
+create or replace function absurd.get_schema_version ()
+  returns text
+  language sql
+as $$
+  select 'main'::text;
+$$;
+
+create or replace function absurd.ensure_queue_tables (p_queue_name text)
+  returns void
+  language plpgsql
+as $$
+declare
+  v_storage_mode text := 'unpartitioned';
+  v_t_suffix text;
+  v_r_suffix text;
+  v_c_suffix text;
+  v_w_suffix text;
+  v_t_idempotency_def text;
+begin
+  perform absurd.validate_queue_name(p_queue_name);
+
+  select storage_mode into v_storage_mode
+  from absurd.queues
+  where queue_name = p_queue_name;
+
+  v_storage_mode := coalesce(v_storage_mode, 'unpartitioned');
+
+  if v_storage_mode not in ('unpartitioned', 'partitioned') then
+    raise exception 'Unsupported queue storage mode "%"', v_storage_mode;
+  end if;
+
+  if v_storage_mode = 'partitioned' then
+    v_t_suffix := 'partition by range (task_id)';
+    v_r_suffix := 'partition by range (run_id)';
+    v_c_suffix := 'partition by range (task_id)';
+    v_w_suffix := 'partition by range (run_id)';
+    v_t_idempotency_def := 'idempotency_key text';
+  else
+    v_t_suffix := 'with (fillfactor=70)';
+    v_r_suffix := 'with (fillfactor=70)';
+    v_c_suffix := 'with (fillfactor=70)';
+    v_w_suffix := '';
+    v_t_idempotency_def := 'idempotency_key text unique';
+  end if;
+
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid primary key,
+        task_name text not null,
+        params jsonb not null,
+        headers jsonb,
+        retry_strategy jsonb,
+        max_attempts integer,
+        cancellation jsonb,
+        enqueue_at timestamptz not null default absurd.current_time(),
+        first_started_at timestamptz,
+        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+        attempts integer not null default 0,
+        last_attempt_run uuid,
+        completed_payload jsonb,
+        cancelled_at timestamptz,
+        %s
+     ) %s',
+    't_' || p_queue_name,
+    v_t_idempotency_def,
+    v_t_suffix
+  );
+
+  execute format(
+    'create table if not exists absurd.%I (
+        run_id uuid primary key,
+        task_id uuid not null,
+        attempt integer not null,
+        state text not null check (state in (''pending'', ''running'', ''sleeping'', ''completed'', ''failed'', ''cancelled'')),
+        claimed_by text,
+        claim_expires_at timestamptz,
+        available_at timestamptz not null,
+        wake_event text,
+        event_payload jsonb,
+        started_at timestamptz,
+        completed_at timestamptz,
+        failed_at timestamptz,
+        result jsonb,
+        failure_reason jsonb,
+        created_at timestamptz not null default absurd.current_time()
+     ) %s',
+    'r_' || p_queue_name,
+    v_r_suffix
+  );
+
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid not null,
+        checkpoint_name text not null,
+        state jsonb,
+        status text not null default ''committed'',
+        owner_run_id uuid,
+        updated_at timestamptz not null default absurd.current_time(),
+        primary key (task_id, checkpoint_name)
+     ) %s',
+    'c_' || p_queue_name,
+    v_c_suffix
+  );
+
+  execute format(
+    'create table if not exists absurd.%I (
+        event_name text primary key,
+        payload jsonb,
+        emitted_at timestamptz not null default absurd.current_time()
+     )',
+    'e_' || p_queue_name
+  );
+
+  execute format(
+    'create table if not exists absurd.%I (
+        task_id uuid not null,
+        run_id uuid not null,
+        step_name text not null,
+        event_name text not null,
+        timeout_at timestamptz,
+        created_at timestamptz not null default absurd.current_time(),
+        primary key (run_id, step_name)
+     ) %s',
+    'w_' || p_queue_name,
+    v_w_suffix
+  );
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create table if not exists absurd.%I (
+          idempotency_key text primary key,
+          task_id uuid not null
+       )',
+      'i_' || p_queue_name
+    );
+  end if;
+
+  execute format(
+    'create index if not exists %I on absurd.%I (state, available_at)',
+    ('r_' || p_queue_name) || '_sai',
+    'r_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (task_id)',
+    ('r_' || p_queue_name) || '_ti',
+    'r_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (claim_expires_at)
+      where state = ''running''
+        and claim_expires_at is not null',
+    ('r_' || p_queue_name) || '_cei',
+    'r_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (task_id)
+      where state in (''pending'', ''sleeping'', ''running'')
+        and cancellation is not null',
+    ('t_' || p_queue_name) || '_aci',
+    't_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (event_name)',
+    ('w_' || p_queue_name) || '_eni',
+    'w_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (task_id)',
+    ('w_' || p_queue_name) || '_ti',
+    'w_' || p_queue_name
+  );
+
+  execute format(
+    'create index if not exists %I on absurd.%I (emitted_at)',
+    ('e_' || p_queue_name) || '_eai',
+    'e_' || p_queue_name
+  );
+
+  if v_storage_mode = 'partitioned' then
+    execute format(
+      'create index if not exists %I on absurd.%I (task_id)',
+      ('i_' || p_queue_name) || '_ti',
+      'i_' || p_queue_name
+    );
+
+    perform absurd.ensure_partitions(p_queue_name);
+  end if;
+end;
+$$;
+
+-- Add the active-cancellation index to queues that already exist.
+do $$
+declare
+  v_queue record;
+begin
+  for v_queue in
+    select queue_name
+      from absurd.queues
+  loop
+    execute format(
+      'create index if not exists %I on absurd.%I (task_id)
+        where state in (''pending'', ''sleeping'', ''running'')
+          and cancellation is not null',
+      ('t_' || v_queue.queue_name) || '_aci',
+      't_' || v_queue.queue_name
+    );
+  end loop;
+end;
+$$;
+
+create or replace function absurd.claim_task (
+  p_queue_name text,
+  p_worker_id text,
+  p_claim_timeout integer default 30,
+  p_qty integer default 1
+)
+  returns table (
+    run_id uuid,
+    task_id uuid,
+    attempt integer,
+    task_name text,
+    params jsonb,
+    retry_strategy jsonb,
+    max_attempts integer,
+    headers jsonb,
+    wake_event text,
+    event_payload jsonb
+  )
+  language plpgsql
+as $$
+declare
+  v_now timestamptz := absurd.current_time();
+  v_claim_timeout integer := greatest(coalesce(p_claim_timeout, 30), 0);
+  v_worker_id text := coalesce(nullif(p_worker_id, ''), 'worker');
+  v_qty integer := greatest(coalesce(p_qty, 1), 1);
+  v_claim_until timestamptz := null;
+  v_sql text;
+  v_expired_run record;
+  v_cancel_candidate record;
+  v_expired_sweep_limit integer;
+begin
+  if v_claim_timeout > 0 then
+    v_claim_until := v_now + make_interval(secs => v_claim_timeout);
+  end if;
+
+  -- Keep claim polling work bounded: process at most v_qty expired leases
+  -- per claim call.
+  v_expired_sweep_limit := greatest(v_qty, 1);
+
+  -- Apply cancellation rules before claiming.
+  --
+  -- Use cancel_task() so lock order stays consistent (runs first, task second)
+  -- with complete_run()/fail_run().
+  for v_cancel_candidate in
+    execute format(
+      'select task_id
+         from absurd.%I
+        where state in (''pending'', ''sleeping'', ''running'')
+          and cancellation is not null
+          and (
+            (
+              (cancellation->>''max_delay'')::bigint is not null
+              and first_started_at is null
+              and extract(epoch from ($1 - enqueue_at)) >= (cancellation->>''max_delay'')::bigint
+            )
+            or
+            (
+              (cancellation->>''max_duration'')::bigint is not null
+              and first_started_at is not null
+              and extract(epoch from ($1 - first_started_at)) >= (cancellation->>''max_duration'')::bigint
+            )
+          )
+        order by task_id',
+      't_' || p_queue_name
+    )
+  using v_now
+  loop
+    perform absurd.cancel_task(p_queue_name, v_cancel_candidate.task_id);
+  end loop;
+
+  for v_expired_run in
+    execute format(
+      'select run_id,
+              claimed_by,
+              claim_expires_at,
+              attempt
+         from absurd.%I
+        where state = ''running''
+          and claim_expires_at is not null
+          and claim_expires_at <= $1
+        order by claim_expires_at, run_id
+        limit $2
+        for update skip locked',
+      'r_' || p_queue_name
+    )
+  using v_now, v_expired_sweep_limit
+  loop
+    perform absurd.fail_run(
+      p_queue_name,
+      v_expired_run.run_id,
+      jsonb_strip_nulls(jsonb_build_object(
+        'name', '$ClaimTimeout',
+        'message', 'worker did not finish task within claim interval',
+        'workerId', v_expired_run.claimed_by,
+        'claimExpiredAt', v_expired_run.claim_expires_at,
+        'attempt', v_expired_run.attempt
+      )),
+      null
+    );
+  end loop;
+
+  v_sql := format(
+    'with candidate as (
+        select r.run_id
+          from absurd.%1$I r
+          join absurd.%2$I t on t.task_id = r.task_id
+         where r.state in (''pending'', ''sleeping'')
+           and t.state in (''pending'', ''sleeping'', ''running'')
+           and r.available_at <= $1
+         order by r.available_at, r.run_id
+         limit $2
+         for update skip locked
+     ),
+     updated as (
+        update absurd.%1$I r
+           set state = ''running'',
+               claimed_by = $3,
+               claim_expires_at = $4,
+               started_at = $1,
+               available_at = $1
+         where run_id in (select run_id from candidate)
+         returning r.run_id, r.task_id, r.attempt
+     ),
+     task_upd as (
+        update absurd.%2$I t
+           set state = ''running'',
+               attempts = greatest(t.attempts, u.attempt),
+               first_started_at = coalesce(t.first_started_at, $1),
+               last_attempt_run = u.run_id
+          from updated u
+         where t.task_id = u.task_id
+         returning t.task_id
+     ),
+     wait_cleanup as (
+        delete from absurd.%3$I w
+         using updated u
+        where w.run_id = u.run_id
+          and w.timeout_at is not null
+          and w.timeout_at <= $1
+        returning w.run_id
+     )
+     select
+       u.run_id,
+       u.task_id,
+       u.attempt,
+       t.task_name,
+       t.params,
+       t.retry_strategy,
+       t.max_attempts,
+      t.headers,
+      r.wake_event,
+      r.event_payload
+     from updated u
+     join absurd.%1$I r on r.run_id = u.run_id
+     join absurd.%2$I t on t.task_id = u.task_id
+     order by r.available_at, u.run_id',
+    'r_' || p_queue_name,
+    't_' || p_queue_name,
+    'w_' || p_queue_name
+  );
+
+  return query execute v_sql using v_now, v_qty, v_worker_id, v_claim_until;
+end;
+$$;

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -27,6 +27,7 @@ def test_new_queue_creates_performance_indexes(client):
     client.create_queue(queue)
 
     assert _index_exists(client.conn, f"r_{queue}", f"r_{queue}_cei")
+    assert _index_exists(client.conn, f"t_{queue}", f"t_{queue}_aci")
     assert _index_exists(client.conn, f"w_{queue}", f"w_{queue}_ti")
     assert _index_exists(client.conn, f"e_{queue}", f"e_{queue}_eai")
 
@@ -60,6 +61,54 @@ def test_lease_expiry_scan_uses_claim_expiry_index(client):
     )
 
     assert f"r_{queue}_cei" in plan
+
+
+def test_cancellation_sweep_uses_active_cancellation_index(client):
+    queue = "index_cancel_sweep"
+    client.create_queue(queue)
+
+    base = datetime(2024, 7, 1, 12, 0, tzinfo=timezone.utc)
+    client.set_fake_now(base)
+
+    client.spawn_task(
+        queue,
+        "cancellable",
+        {"value": 1},
+        {"cancellation": {"max_delay": 1}},
+    )
+    for offset in range(5):
+        client.spawn_task(queue, f"regular-{offset}", {"value": offset})
+
+    client.conn.execute("set enable_seqscan = off")
+    plan = _explain(
+        client.conn,
+        sql.SQL(
+            """
+            explain select task_id
+            from absurd.{t}
+            where state in ('pending', 'sleeping', 'running')
+              and cancellation is not null
+              and (
+                (
+                  (cancellation->>'max_delay')::bigint is not null
+                  and first_started_at is null
+                  and extract(epoch from (%s - enqueue_at)) >= (cancellation->>'max_delay')::bigint
+                )
+                or
+                (
+                  (cancellation->>'max_duration')::bigint is not null
+                  and first_started_at is not null
+                  and extract(epoch from (%s - first_started_at)) >= (cancellation->>'max_duration')::bigint
+                )
+              )
+            order by task_id
+            limit 1
+            """
+        ).format(t=client.get_table("t", queue)),
+        (base + timedelta(seconds=2), base + timedelta(seconds=2)),
+    )
+
+    assert f"t_{queue}_aci" in plan
 
 
 def test_event_ttl_ordering_uses_emitted_at_index(client):


### PR DESCRIPTION
See [issue in super secret repo](https://github.com/earendil-works/elwing/issues/1568#issuecomment-5243600437).

We have a worker health issue where we keep getting errors in Sentry (never wanted to stop getting an email more in my life!) bc `absurd.claim_task()` does a cancellation sweep on every claim.

Current `absurd.t_default`:

```txt
 total tasks:                  1,546,843
 active pending/sleeping/running:       0 at count time, transiently a few
 active with cancellation:              0
 any task with cancellation:             0
```

Breakdown:

```txt
 completed, cancellation IS NULL: 1,544,940
 failed,    cancellation IS NULL:     1,903
```

So in current prod, 100% of rows have cancellation IS NULL.

That means changing the sweep to:

```sql
 WHERE state IN ('pending', 'sleeping', 'running')
   AND cancellation IS NOT NULL
```

plus adding the partial index:

```sql
 CREATE INDEX ...
 ON absurd.t_default (task_id)
 WHERE state IN ('pending', 'sleeping', 'running')
   AND cancellation IS NOT NULL;
```

would make the cancellation sweep query an empty/tiny index instead of scanning ~1.55M rows.

This PR adds that :)