### PR TITLE
Reconnect the Python async client's owned connection after an interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This contains the changes between releases.
 
 # Unreleased
 
+* Fixed the Python SDK's async client to reconnect when its owned connection was interrupted (e.g. by an idle timeout or a server restart) instead of failing every later call with "the connection is closed".
+
 # 0.5.0
 
 * Added a Habitat tasks filter for terminal failures and defaulted the failed status view to hide failed attempts that were retried later.

--- a/sdks/python/src/absurd_sdk/__init__.py
+++ b/sdks/python/src/absurd_sdk/__init__.py
@@ -1844,7 +1844,10 @@ class AsyncAbsurd(_AbsurdBase):
         )
 
     async def _ensure_connected(self) -> None:
-        """Ensure the connection is established"""
+        """Ensure the connection is established, replacing an owned connection
+        that was interrupted (e.g. by an idle timeout or a server restart)."""
+        if self._conn is not None and self._owned_conn and self._conn.broken:
+            self._conn = None
         if self._conn is None and self._conn_string:
             self._conn = await AsyncConnection.connect(
                 self._conn_string, autocommit=True

--- a/sdks/python/tests/test_connection_defaults.py
+++ b/sdks/python/tests/test_connection_defaults.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 import absurd_sdk
 
 
@@ -49,7 +51,7 @@ def test_async_absurd_falls_back_to_default_absurd_uri(monkeypatch):
     assert client._owned_conn is True
 
 
-class _FakeAsyncConnection:
+class MockConnection:
     def __init__(self):
         self.broken = False
         self.closed = False
@@ -58,64 +60,61 @@ class _FakeAsyncConnection:
         self.closed = True
 
 
-def test_async_absurd_reuses_a_healthy_owned_connection(monkeypatch):
-    connections = []
+@pytest.fixture
+def connections(monkeypatch):
+    """The connections handed out by a patched `AsyncConnection.connect`, in order."""
+    made = []
 
-    async def fake_connect(dsn, autocommit=True):
-        connection = _FakeAsyncConnection()
-        connections.append(connection)
-        return connection
+    async def connect(dsn, autocommit=True):
+        made.append(MockConnection())
+        return made[-1]
 
-    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", fake_connect)
+    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", connect)
+    return made
+
+
+def test_async_absurd_reuses_a_healthy_owned_connection(connections):
     client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
 
-    asyncio.run(client._ensure_connected())
-    asyncio.run(client._ensure_connected())
+    async def run():
+        await client._ensure_connected()
+        await client._ensure_connected()
 
-    assert len(connections) == 1
-    assert client._conn is connections[0]
+    asyncio.run(run())
+
+    assert connections == [client._conn]
 
 
-def test_async_absurd_replaces_an_interrupted_owned_connection(monkeypatch):
-    connections = []
-
-    async def fake_connect(dsn, autocommit=True):
-        connection = _FakeAsyncConnection()
-        connections.append(connection)
-        return connection
-
-    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", fake_connect)
+def test_async_absurd_replaces_an_interrupted_owned_connection(connections):
     client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
 
-    asyncio.run(client._ensure_connected())
-    connections[0].broken = True
-    asyncio.run(client._ensure_connected())
+    async def run():
+        await client._ensure_connected()
+        connections[0].broken = True
+        await client._ensure_connected()
+
+    asyncio.run(run())
 
     assert len(connections) == 2
     assert client._conn is connections[1]
 
 
-def test_async_absurd_does_not_reconnect_after_an_explicit_close(monkeypatch):
-    connections = []
-
-    async def fake_connect(dsn, autocommit=True):
-        connection = _FakeAsyncConnection()
-        connections.append(connection)
-        return connection
-
-    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", fake_connect)
+def test_async_absurd_does_not_reconnect_after_an_explicit_close(connections):
     client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
 
-    asyncio.run(client._ensure_connected())
-    asyncio.run(client.close())
-    asyncio.run(client._ensure_connected())
+    async def run():
+        await client._ensure_connected()
+        await client.close()
+        await client._ensure_connected()
 
-    assert len(connections) == 1
-    assert client._conn is connections[0]
+    asyncio.run(run())
+
+    assert connections == [client._conn]
+    assert client._conn.closed
 
 
 def test_async_absurd_does_not_replace_an_injected_broken_connection():
-    connection = _FakeAsyncConnection()
+    connection = MockConnection()
     connection.broken = True
     client = absurd_sdk.AsyncAbsurd(connection)
 

--- a/sdks/python/tests/test_connection_defaults.py
+++ b/sdks/python/tests/test_connection_defaults.py
@@ -1,5 +1,8 @@
 import asyncio
 
+import psycopg
+from psycopg import pq
+
 import absurd_sdk
 
 
@@ -49,18 +52,14 @@ def test_async_absurd_falls_back_to_default_absurd_uri(monkeypatch):
     assert client._owned_conn is True
 
 
-class MockConnection:
-    broken = False
-
-    async def close(self):
-        pass
-
-
-def test_async_absurd_reconnects_only_after_an_interrupted_connection(monkeypatch):
+def test_async_absurd_reconnects_after_an_interrupted_connection(monkeypatch):
     made = []
 
     async def connect(dsn, autocommit=True):
-        made.append(MockConnection())
+        # Connecting to a nonexistent socket fails immediately, producing a
+        # real psycopg connection that is `broken`: status BAD without a
+        # clean close(), the same state a dropped connection leaves behind.
+        made.append(psycopg.AsyncConnection(pq.PGconn.connect(b"host=/nonexistent")))
         return made[-1]
 
     monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", connect)
@@ -68,10 +67,7 @@ def test_async_absurd_reconnects_only_after_an_interrupted_connection(monkeypatc
 
     async def run():
         await client._ensure_connected()
-        made[0].broken = True
-        await client._ensure_connected()  # interrupted: replaced
-        await client.close()
-        await client._ensure_connected()  # closed cleanly: not resurrected
+        await client._ensure_connected()
 
     asyncio.run(run())
 

--- a/sdks/python/tests/test_connection_defaults.py
+++ b/sdks/python/tests/test_connection_defaults.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import absurd_sdk
 
 
@@ -45,3 +47,78 @@ def test_async_absurd_falls_back_to_default_absurd_uri(monkeypatch):
 
     assert client._conn_string == "postgresql://localhost/absurd"
     assert client._owned_conn is True
+
+
+class _FakeAsyncConnection:
+    def __init__(self):
+        self.broken = False
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def test_async_absurd_reuses_a_healthy_owned_connection(monkeypatch):
+    connections = []
+
+    async def fake_connect(dsn, autocommit=True):
+        connection = _FakeAsyncConnection()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", fake_connect)
+    client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
+
+    asyncio.run(client._ensure_connected())
+    asyncio.run(client._ensure_connected())
+
+    assert len(connections) == 1
+    assert client._conn is connections[0]
+
+
+def test_async_absurd_replaces_an_interrupted_owned_connection(monkeypatch):
+    connections = []
+
+    async def fake_connect(dsn, autocommit=True):
+        connection = _FakeAsyncConnection()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", fake_connect)
+    client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
+
+    asyncio.run(client._ensure_connected())
+    connections[0].broken = True
+    asyncio.run(client._ensure_connected())
+
+    assert len(connections) == 2
+    assert client._conn is connections[1]
+
+
+def test_async_absurd_does_not_reconnect_after_an_explicit_close(monkeypatch):
+    connections = []
+
+    async def fake_connect(dsn, autocommit=True):
+        connection = _FakeAsyncConnection()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", fake_connect)
+    client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
+
+    asyncio.run(client._ensure_connected())
+    asyncio.run(client.close())
+    asyncio.run(client._ensure_connected())
+
+    assert len(connections) == 1
+    assert client._conn is connections[0]
+
+
+def test_async_absurd_does_not_replace_an_injected_broken_connection():
+    connection = _FakeAsyncConnection()
+    connection.broken = True
+    client = absurd_sdk.AsyncAbsurd(connection)
+
+    asyncio.run(client._ensure_connected())
+
+    assert client._conn is connection

--- a/sdks/python/tests/test_connection_defaults.py
+++ b/sdks/python/tests/test_connection_defaults.py
@@ -50,15 +50,13 @@ def test_async_absurd_falls_back_to_default_absurd_uri(monkeypatch):
 
 
 class MockConnection:
-    def __init__(self):
-        self.broken = False
-        self.closed = False
+    broken = False
 
     async def close(self):
-        self.closed = True
+        pass
 
 
-def test_async_absurd_replaces_an_interrupted_owned_connection(monkeypatch):
+def test_async_absurd_reconnects_only_after_an_interrupted_connection(monkeypatch):
     made = []
 
     async def connect(dsn, autocommit=True):
@@ -71,30 +69,11 @@ def test_async_absurd_replaces_an_interrupted_owned_connection(monkeypatch):
     async def run():
         await client._ensure_connected()
         made[0].broken = True
-        await client._ensure_connected()
+        await client._ensure_connected()  # interrupted: replaced
+        await client.close()
+        await client._ensure_connected()  # closed cleanly: not resurrected
 
     asyncio.run(run())
 
     assert len(made) == 2
     assert client._conn is made[1]
-
-
-def test_async_absurd_does_not_reconnect_after_an_explicit_close(monkeypatch):
-    made = []
-
-    async def connect(dsn, autocommit=True):
-        made.append(MockConnection())
-        return made[-1]
-
-    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", connect)
-    client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
-
-    async def run():
-        await client._ensure_connected()
-        await client.close()
-        await client._ensure_connected()
-
-    asyncio.run(run())
-
-    assert made == [client._conn]
-    assert client._conn.closed

--- a/sdks/python/tests/test_connection_defaults.py
+++ b/sdks/python/tests/test_connection_defaults.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import psycopg
-from psycopg import pq
 
 import absurd_sdk
 
@@ -59,7 +58,7 @@ def test_async_absurd_reconnects_after_an_interrupted_connection(monkeypatch):
         # Connecting to a nonexistent socket fails immediately, producing a
         # real psycopg connection that is `broken`: status BAD without a
         # clean close(), the same state a dropped connection leaves behind.
-        made.append(psycopg.AsyncConnection(pq.PGconn.connect(b"host=/nonexistent")))
+        made.append(psycopg.AsyncConnection(psycopg.pq.PGconn.connect(b"host=/nonexistent")))
         return made[-1]
 
     monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", connect)

--- a/sdks/python/tests/test_connection_defaults.py
+++ b/sdks/python/tests/test_connection_defaults.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import pytest
-
 import absurd_sdk
 
 
@@ -60,9 +58,7 @@ class MockConnection:
         self.closed = True
 
 
-@pytest.fixture
-def connections(monkeypatch):
-    """The connections handed out by a patched `AsyncConnection.connect`, in order."""
+def test_async_absurd_replaces_an_interrupted_owned_connection(monkeypatch):
     made = []
 
     async def connect(dsn, autocommit=True):
@@ -70,36 +66,27 @@ def connections(monkeypatch):
         return made[-1]
 
     monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", connect)
-    return made
-
-
-def test_async_absurd_reuses_a_healthy_owned_connection(connections):
     client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
 
     async def run():
         await client._ensure_connected()
+        made[0].broken = True
         await client._ensure_connected()
 
     asyncio.run(run())
 
-    assert connections == [client._conn]
+    assert len(made) == 2
+    assert client._conn is made[1]
 
 
-def test_async_absurd_replaces_an_interrupted_owned_connection(connections):
-    client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
+def test_async_absurd_does_not_reconnect_after_an_explicit_close(monkeypatch):
+    made = []
 
-    async def run():
-        await client._ensure_connected()
-        connections[0].broken = True
-        await client._ensure_connected()
+    async def connect(dsn, autocommit=True):
+        made.append(MockConnection())
+        return made[-1]
 
-    asyncio.run(run())
-
-    assert len(connections) == 2
-    assert client._conn is connections[1]
-
-
-def test_async_absurd_does_not_reconnect_after_an_explicit_close(connections):
+    monkeypatch.setattr(absurd_sdk.AsyncConnection, "connect", connect)
     client = absurd_sdk.AsyncAbsurd("postgresql://localhost/absurd")
 
     async def run():
@@ -109,15 +96,5 @@ def test_async_absurd_does_not_reconnect_after_an_explicit_close(connections):
 
     asyncio.run(run())
 
-    assert connections == [client._conn]
+    assert made == [client._conn]
     assert client._conn.closed
-
-
-def test_async_absurd_does_not_replace_an_injected_broken_connection():
-    connection = MockConnection()
-    connection.broken = True
-    client = absurd_sdk.AsyncAbsurd(connection)
-
-    asyncio.run(client._ensure_connected())
-
-    assert client._conn is connection

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -7,10 +7,6 @@ resolution-markers = [
     "python_full_version < '3.9.2'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "absurd-sdk"
 version = "0.5.0"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.9.2'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "absurd-sdk"
 version = "0.5.0"


### PR DESCRIPTION
`AsyncAbsurd._ensure_connected` only connects when `_conn is None`, and nothing ever resets `_conn`, so an owned connection that dies underneath the client (idle timeout, server restart, network blip) is terminal: every later call raises `psycopg.OperationalError: the connection is closed` until the process restarts. We hit this in production with a long-lived client whose connection sits idle between scheduler ticks; one dropped connection permanently broke every subsequent `spawn`.

This makes `_ensure_connected` treat an owned connection whose `broken` flag is set as reconnectable. psycopg's `broken` is true only for connections that terminated abnormally, so:

- an explicitly `close()`d client stays closed (no surprise resurrection),
- an injected connection (`_owned_conn = False`) is never replaced, since the caller owns its lifecycle.

The call that discovers the dead connection still raises (psycopg only marks the connection broken when an operation fails on it); the next call reconnects instead of failing forever.

The sync client connects eagerly in `__init__` and doesn't keep the conn string, so it isn't covered here; happy to follow up on it (and the TS SDK, which looks similar) if you want the same semantics there.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
